### PR TITLE
removed wording that claimed we support XP and Vista

### DIFF
--- a/OpenParrotLoader/src/main.cpp
+++ b/OpenParrotLoader/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 	char szDir2[512];
 	printf("OpenParrot Loader\n");
 	printf("http://www.teknogods.com - Modding Gurus!\n");
-	printf("Supported OS: Windows XP x86 / x64, Windows Vista x86 / x64, Windows 7 x86 / x64, Windows 8 / 8.1 x86 / x64 Windows 10 x86 / x64\n");
+	printf("Supported OS: Windows 7 x86 / x64, Windows 8 / 8.1 x86 / x64 Windows 10 x86 / x64\n");
 	printf("Code: Reaver, NTAuthority, avail and the community\n");
 	GetCurrentDirectoryA(400, szDir);
 	sprintf_s(szDir2, "%s\\%s.dll", szDir, argv[1]);


### PR DESCRIPTION
those OS'es are old, please update your computer rather then run XP or Vista (it won't even run on XP anyway, since it's compiled for VS2019)