### PR TITLE
H2Overdrive control FIX v2

### DIFF
--- a/OpenParrot/src/Functions/Games/Other/FNFSuperBikes2.cpp
+++ b/OpenParrot/src/Functions/Games/Other/FNFSuperBikes2.cpp
@@ -286,6 +286,7 @@ DWORD WINAPI InputRT5(LPVOID lpParam)
 				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_N), 2, true);
 				button1pressed = true;
 			}
+
 		}
 		else
 		{
@@ -314,6 +315,14 @@ DWORD WINAPI InputRT5(LPVOID lpParam)
 				injector::WriteMemoryRaw((0x21D7E + BaseAddress5), "\x90\x90 ", 2, true);
 				injector::WriteMemoryRaw((0x21D8C + BaseAddress5), "\x90\x90", 2, true);
 				button2pressed = true;
+			}
+			else if (button2pressed == true)
+			{
+				injector::WriteMemoryRaw((0x718F8 + BaseAddress5), "\x8C\xD7 ", 2, true);
+				injector::WriteMemoryRaw((0x718F5 + BaseAddress5), "\x74\x14", 2, true);
+
+				injector::WriteMemoryRaw((0x21D7E + BaseAddress5), "\x74\x76 ", 2, true);
+				injector::WriteMemoryRaw((0x21D8C + BaseAddress5), "\x74\x19", 2, true);
 			}
 		}
 		else

--- a/OpenParrot/src/Functions/Games/Other/H2Overdrive.cpp
+++ b/OpenParrot/src/Functions/Games/Other/H2Overdrive.cpp
@@ -133,6 +133,10 @@ DWORD WINAPI InputRT10(LPVOID lpParam)
 					injector::WriteMemory<INT32>((ptr + 0x840), 1, true);
 				}
 			}
+			else if (button2pressed == true)
+			{
+				injector::WriteMemory<INT32>((0x398CBC + BaseAddress10), 0, true);
+			}
 		}
 		else
 		{
@@ -171,6 +175,7 @@ DWORD WINAPI InputRT10(LPVOID lpParam)
 		{
 			if (button4pressed == false)
 			{
+				injector::WriteMemory<INT32>((0x398CB8 + BaseAddress10), 1, true); // MENU COUNTDOWN HACK
 				keybd_event(0x2D, MapVirtualKey(0x2D, MAPVK_VK_TO_VSC), 0, 0);
 				button4pressed = true;
 			}
@@ -179,6 +184,7 @@ DWORD WINAPI InputRT10(LPVOID lpParam)
 		{
 			if (button4pressed == true)
 			{
+				injector::WriteMemory<INT32>((0x398CB8 + BaseAddress10), 0, true); // MENU COUNTDOWN HACK
 				keybd_event(0x2D, MapVirtualKey(0x2D, MAPVK_VK_TO_VSC), KEYEVENTF_KEYUP, 0);
 				button4pressed = false;
 			}


### PR DESCRIPTION
H2Overdrive final controls fix:
- VIEW button in menu is NOT autofire anymore
- use SERVICE key to speed up the counter in menus