### PR TITLE
Basic SpiceTools / Konami support

### DIFF
--- a/OpenParrot/src/Functions/Games/Other/Konami.cpp
+++ b/OpenParrot/src/Functions/Games/Other/Konami.cpp
@@ -53,6 +53,33 @@ static char __cdecl ac_io_hbhi_update_control_status_buffer()
             STATUS_BUFFER[4] |= 1;
         }
 
+        // player 1 red
+        if (buttons & BUTTON2)
+        {
+            STATUS_BUFFER[12] |= 1 << 0;
+        }
+
+        // player 1 blue
+        if (buttons & BUTTON3)
+        {
+            STATUS_BUFFER[12] |= 1 << 1;
+        }
+
+        // player 1 yellow
+        if (buttons & BUTTON4)
+        {
+            STATUS_BUFFER[12] |= 1 << 2;
+        }
+
+        // player 1 green
+        if (buttons & BUTTON5)
+        {
+            STATUS_BUFFER[12] |= 1 << 3;
+        }
+
+        // TODO: player 2
+        STATUS_BUFFER[6] |= 1;
+
         break;
     }
 

--- a/OpenParrot/src/Functions/Games/Other/Konami.cpp
+++ b/OpenParrot/src/Functions/Games/Other/Konami.cpp
@@ -1,0 +1,79 @@
+#include <StdInc.h>
+#include "Utility/InitFunction.h"
+#include "Functions/Global.h"
+#include "Utility/GameDetect.h"
+#include <math.h>
+
+// controls
+extern int* ffbOffset;
+static uint8_t STATUS_BUFFER[64]{};
+
+static void* __cdecl ac_io_hbhi_get_control_status_buffer(uint8_t* buffer)
+{
+    //Beep(100, 100);
+
+	memcpy(buffer, STATUS_BUFFER, 64);
+	return buffer;
+}
+
+static char __cdecl ac_io_hbhi_update_control_status_buffer() 
+{
+    switch (GameDetect::KonamiGame)
+    {
+    case KonamiGame::HelloPopnMusic:
+        memset(STATUS_BUFFER, 0x00, 64);
+
+        // TODO: make the buttons actually work, and add the rest of them
+        
+        // service
+        if (*ffbOffset & 0x01)
+        {
+            Beep(100, 100);
+            STATUS_BUFFER[5] |= 1 << 4;
+        }
+
+        // test
+        if (*ffbOffset & 0x02)
+        {
+            Beep(100, 100);
+            STATUS_BUFFER[5] |= 1 << 5;
+        }
+
+        // player 1 start  
+        //if (*ffbOffset & 0x04) 
+        {
+            //Beep(100, 100);
+            STATUS_BUFFER[4] |= 1;
+        }
+
+        break;
+    }
+
+    return true;
+}
+
+DWORD WINAPI KonamiInput(LPVOID lpParam)
+{
+	// wait for SpiceTools to hook IO stuff.
+	Sleep(1000);
+
+    // and replace it's IO hooks with ours >:)
+    LoadLibraryA("libacio.dll");
+
+    MH_Initialize();
+    MH_CreateHookApi(L"libacio.dll", "ac_io_hbhi_get_control_status_buffer", ac_io_hbhi_get_control_status_buffer, NULL);
+    MH_CreateHookApi(L"libacio.dll", "ac_io_hbhi_update_control_status_buffer", ac_io_hbhi_update_control_status_buffer, NULL);
+    MH_EnableHook(MH_ALL_HOOKS);
+    Beep(500, 500);
+    //while (true)
+    //{
+    //    Sleep(100);
+    //}
+
+    return 0;
+}
+
+static InitFunction KonamiFunc([]()
+{
+	CreateThread(NULL, 0, KonamiInput, NULL, 0, NULL);
+}, GameID::Konami);

--- a/OpenParrot/src/Functions/Games/Other/Konami.cpp
+++ b/OpenParrot/src/Functions/Games/Other/Konami.cpp
@@ -8,23 +8,26 @@
 extern int* ffbOffset;
 static uint8_t STATUS_BUFFER[64]{};
 
-constexpr auto SERVICE  = (1 << 0);
-constexpr auto TEST     = (1 << 1);
-constexpr auto BUTTON1  = (1 << 2);
-constexpr auto BUTTON2  = (1 << 3);
-constexpr auto BUTTON3  = (1 << 4);
-constexpr auto BUTTON4  = (1 << 5);
-constexpr auto BUTTON5  = (1 << 6);
-constexpr auto BUTTON6  = (1 << 7);
-constexpr auto BUTTON7  = (1 << 8);
-constexpr auto BUTTON8  = (1 << 9);
-constexpr auto BUTTON9  = (1 << 10);
-constexpr auto BUTTON10 = (1 << 11);
+enum Buttons
+{
+    SERVICE = (1 << 0),
+    TEST = (1 << 1),
+    BUTTON1 = (1 << 2),
+    BUTTON2 = (1 << 3),
+    BUTTON3 = (1 << 4),
+    BUTTON4 = (1 << 5),
+    BUTTON5 = (1 << 6),
+    BUTTON6 = (1 << 7),
+    BUTTON7 = (1 << 8),
+    BUTTON8 = (1 << 9),
+    BUTTON9 = (1 << 10),
+    BUTTON10 = (1 << 11),
+};
 
 static void* __cdecl ac_io_hbhi_get_control_status_buffer(uint8_t* buffer)
 {
-	memcpy(buffer, STATUS_BUFFER, 64);
-	return buffer;
+    memcpy(buffer, STATUS_BUFFER, 64);
+    return buffer;
 }
 
 static char __cdecl ac_io_hbhi_update_control_status_buffer() 
@@ -77,8 +80,35 @@ static char __cdecl ac_io_hbhi_update_control_status_buffer()
             STATUS_BUFFER[12] |= 1 << 3;
         }
 
-        // TODO: player 2
-        STATUS_BUFFER[6] |= 1;
+        // player 2 start
+        if (!(buttons & BUTTON6))
+        {
+            STATUS_BUFFER[6] |= 1;
+        }
+
+        // player 1 red
+        if (buttons & BUTTON7)
+        {
+            STATUS_BUFFER[12] |= 1 << 4;
+        }
+
+        // player 1 blue
+        if (buttons & BUTTON8)
+        {
+            STATUS_BUFFER[12] |= 1 << 5;
+        }
+
+        // player 1 yellow
+        if (buttons & BUTTON9)
+        {
+            STATUS_BUFFER[12] |= 1 << 6;
+        }
+
+        // player 1 green
+        if (buttons & BUTTON10)
+        {
+            STATUS_BUFFER[12] |= 1 << 7;
+        }
 
         break;
     }
@@ -88,8 +118,8 @@ static char __cdecl ac_io_hbhi_update_control_status_buffer()
 
 DWORD WINAPI KonamiInput(LPVOID lpParam)
 {
-	// wait for SpiceTools to hook IO stuff.
-	Sleep(500);
+    // wait for SpiceTools to hook IO stuff.
+    Sleep(500);
     OutputDebugStringA("openparrot: attaching");
 
     // and replace it's IO hooks with ours >:)
@@ -111,5 +141,5 @@ DWORD WINAPI KonamiInput(LPVOID lpParam)
 
 static InitFunction KonamiFunc([]()
 {
-	CreateThread(NULL, 0, KonamiInput, NULL, 0, NULL); 
+    CreateThread(NULL, 0, KonamiInput, NULL, 0, NULL); 
 }, GameID::Konami);

--- a/OpenParrot/src/Functions/Games/TypeX2/DirectInputWrapper.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/DirectInputWrapper.cpp
@@ -376,7 +376,7 @@ HRESULT __stdcall Hook_DirectInput8Create(HINSTANCE hinst, DWORD dwVersion, REFI
 
 static InitFunction initFunc([]() 
 {
-	if (GameDetect::currentGame == GameID::PokkenTournament || GameDetect::currentGame == GameID::FNFDrift || GameDetect::currentGame == GameID::FNFSC || GameDetect::currentGame == GameID::FNF || GameDetect::currentGame == GameID::FNFSB || GameDetect::currentGame == GameID::FNFSB2 || GameDetect::currentGame == GameID::GHA || GameDetect::currentGame == GameID::JLeague)
+	if (GameDetect::currentGame == GameID::PokkenTournament || GameDetect::currentGame == GameID::FNFDrift || GameDetect::currentGame == GameID::FNFSC || GameDetect::currentGame == GameID::FNF || GameDetect::currentGame == GameID::FNFSB || GameDetect::currentGame == GameID::FNFSB2 || GameDetect::currentGame == GameID::GHA || GameDetect::currentGame == GameID::JLeague || GameDetect::currentGame == GameID::Konami)
 		return;
 	MH_Initialize();
 

--- a/OpenParrot/src/Functions/Types.h
+++ b/OpenParrot/src/Functions/Types.h
@@ -13,3 +13,7 @@ enum class X2Type {
 	MB4,
 	Wontertainment,
 };
+enum class KonamiGame {
+	None,
+	HelloPopnMusic,
+};

--- a/OpenParrot/src/Functions/WindowedDx8.cpp
+++ b/OpenParrot/src/Functions/WindowedDx8.cpp
@@ -88,9 +88,7 @@ extern linb::ini config;
 
 static InitFunction initFunc([]()
 {
-	if (GameDetect::currentGame == GameID::BG4)
-		return;
-	if (GameDetect::currentGame == GameID::TER)
+	if (GameDetect::currentGame == GameID::BG4 || GameDetect::currentGame == GameID::TER || GameDetect::currentGame == GameID::Konami)
 		return;
 	if (GameDetect::currentGame == GameID::FNFSC)
 		InitD3D8WindowHook();

--- a/OpenParrot/src/Functions/WindowedDx9.cpp
+++ b/OpenParrot/src/Functions/WindowedDx9.cpp
@@ -70,7 +70,7 @@ extern linb::ini config;
 
 static InitFunction initFunc([]()
 {
-	if (GameDetect::currentGame == GameID::BG4 || GameDetect::currentGame == GameID::JLeague || GameDetect::currentGame == GameID::TER)
+	if (GameDetect::currentGame == GameID::BG4 || GameDetect::currentGame == GameID::JLeague || GameDetect::currentGame == GameID::TER || GameDetect::currentGame == GameID::Konami)
 		return;
 	if (ToBool(config["General"]["Windowed"]))
 	{

--- a/OpenParrot/src/Functions/WindowedDxgi.cpp
+++ b/OpenParrot/src/Functions/WindowedDxgi.cpp
@@ -241,7 +241,7 @@ extern linb::ini config;
 
 static InitFunction initFunc([]()
 {
-	if (GameDetect::currentGame == GameID::PokkenTournament || GameDetect::currentGame == GameID::SchoolOfRagnarok || GameDetect::currentGame == GameID::TER)
+	if (GameDetect::currentGame == GameID::PokkenTournament || GameDetect::currentGame == GameID::SchoolOfRagnarok || GameDetect::currentGame == GameID::TER || GameDetect::currentGame == GameID::Konami)
 		return;
 	if (ToBool(config["General"]["Windowed"]))
 	{

--- a/OpenParrot/src/Utility/GameDetect.cpp
+++ b/OpenParrot/src/Utility/GameDetect.cpp
@@ -26,6 +26,14 @@ void GameDetect::DetectCurrentGame(bool konami)
 		if (file_exists("popn.dll"))
 			KonamiGame = KonamiGame::HelloPopnMusic;
 
+		if (KonamiGame == KonamiGame::None)
+		{
+			MessageBoxA(0, "Unsupported Konami Game!", "Error", MB_ICONERROR);
+			Sleep(100);
+			ExitProcess(0);
+			return;
+		}
+
 		return;
 	}
 	uint32_t crcResult = GetCRC32(GetModuleHandle(nullptr), 0x400);

--- a/OpenParrot/src/Utility/GameDetect.cpp
+++ b/OpenParrot/src/Utility/GameDetect.cpp
@@ -6,13 +6,29 @@ bool GameDetect::isNesica = false;
 bool GameDetect::enableNesysEmu = true;
 NesicaKey GameDetect::NesicaKey;
 X2Type GameDetect::X2Type = X2Type::None;
+KonamiGame GameDetect::KonamiGame = KonamiGame::None;
 static char newCrc[0x400];
 static char errorBuffer[256];
 
-void GameDetect::DetectCurrentGame()
+bool GameDetect::file_exists(const std::string& name)
 {
-	uint32_t crcResult = GetCRC32(GetModuleHandle(nullptr), 0x400);
+	struct stat buffer;
+	return (stat(name.c_str(), &buffer) == 0);
+}
+
+void GameDetect::DetectCurrentGame(bool konami)
+{
 	NesicaKey = NesicaKey::None;
+	if (konami)
+	{
+		currentGame = GameID::Konami;
+
+		if (file_exists("popn.dll"))
+			KonamiGame = KonamiGame::HelloPopnMusic;
+
+		return;
+	}
+	uint32_t crcResult = GetCRC32(GetModuleHandle(nullptr), 0x400);
 	switch (crcResult)
 	{
 #if _M_IX86

--- a/OpenParrot/src/Utility/GameDetect.h
+++ b/OpenParrot/src/Utility/GameDetect.h
@@ -6,14 +6,16 @@ class GameDetect
 {
 public:
 	static GameID currentGame;
-	static void DetectCurrentGame();
+	static void DetectCurrentGame(bool konami = false);
 	static X2Type X2Type;
+	static KonamiGame KonamiGame;
 	static bool IsTypeX();
 	static bool IsNesicaGame();
 	static NesicaKey NesicaKey;
 	static std::string GetGameName();
 	static std::string GameDetect::GetGameName(GameID game);
 	static bool enableNesysEmu;
+	static bool file_exists(const std::string& name);
 
 private:
 	static bool isNesica;

--- a/OpenParrot/src/Utility/GameID.h
+++ b/OpenParrot/src/Utility/GameID.h
@@ -69,5 +69,6 @@ enum class GameID
 	DirtyDrivin,
 	H2Overdrive,
 	Tekken7Update00,
-	Tekken7Update12
+	Tekken7Update12,
+	Konami
 };

--- a/OpenParrot/src/dllmain.cpp
+++ b/OpenParrot/src/dllmain.cpp
@@ -95,6 +95,14 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 {
 	if (ul_reason_for_call == DLL_PROCESS_ATTACH)
 	{
+		// SpiceTools 
+		if (GameDetect::file_exists("spice.exe") || GameDetect::file_exists("spice64.exe"))
+		{
+			GameDetect::DetectCurrentGame(true);
+			InitFunction::RunFunctions(GameID::Global);
+			InitFunction::RunFunctions(GameDetect::currentGame);
+			return TRUE;
+		}
 #ifdef DEVMODE
 		RunMain();
 #else

--- a/OpenParrot/src/dllmain.cpp
+++ b/OpenParrot/src/dllmain.cpp
@@ -95,7 +95,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
 {
 	if (ul_reason_for_call == DLL_PROCESS_ATTACH)
 	{
-		// SpiceTools 
+		// SpiceTools detection
 		if (GameDetect::file_exists("spice.exe") || GameDetect::file_exists("spice64.exe"))
 		{
 			GameDetect::DetectCurrentGame(true);


### PR DESCRIPTION
``OutputDebugStringA`` is used for log messages because spicetools outputs it to it's log.