### PR TITLE
Bookeeping and TGM3 FIxes

### DIFF
--- a/OpenParrot/src/Utility/Utils.cpp
+++ b/OpenParrot/src/Utility/Utils.cpp
@@ -56,6 +56,11 @@ bool ToBool(const std::string& s)
 	return !!Compare(s, "false", false);
 }
 
+int ToInt(const std::string& s) // handy function
+{
+        return stoi(s);		// real simple. :)
+}
+
 bool IpToByte(const char* ip, char bytes[4])
 {
 	return (sscanf(ip, "%hhu.%hhu.%hhu.%hhu", &bytes[0], &bytes[1], &bytes[2], &bytes[3]) == 4);

--- a/OpenParrot/src/Utility/Utils.h
+++ b/OpenParrot/src/Utility/Utils.h
@@ -139,6 +139,7 @@ static DWORD crc_32_tab[] = {
 	0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d };
 
 bool ToBool(const std::string& s);
+int ToInt(const std::string& s); // for reading ints from game profiles inside of openparrot.dll
 
 bool IpToByte(const char* ip, char bytes[4]);
 


### PR DESCRIPTION
This patches TGM3 to allow user resolution, windowed mode, and bookkeeping in TeknoParrot directory.

It ALSO attempts to patch most other bookkeeping in typex games. it has succeeded where the old patch failed in every game i've tried. :)

Needs a new revision 6 config file for TGM3, to specify resolution.  

Hopefully will close #90 and #75. i've really only tested kof98 and MIRA.
