### PR TITLE
- BG4: Fix sound balance

### DIFF
--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -1155,6 +1155,9 @@ static InitFunction initFunction([]()
 			// redirect E:\data to .\data
 			injector::WriteMemoryRaw(0x0076D96C, "./data/", 8, true);
 			injector::WriteMemoryRaw(0x007ACA60, ".\\data", 7, true);
+			
+			// Fix sound only being in left ear
+			injector::WriteMemoryRaw(imageBase + 0x36C3DC, "\x00\x60\xA9\x45", 4, true);
 
 			if (ToBool(config["General"]["IntroFix"]))
 			{


### PR DESCRIPTION
Added code fixes sound being stuck in left ear for BG4 tuned (seems GBR version already has working sound). Tested on latest OpenParrot.
Video: https://cdn.discordapp.com/attachments/614185985755971609/732553279329927198/2020-07-14_12-01-51.mp4