### PR TITLE
[Taiko no Tatsujin Nijiiro Ver.] Fix input sensitivity (fixes drum rolls)

### DIFF
--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -75,28 +75,44 @@ static __int64 __fastcall bnusio_DecService(int a1, unsigned __int16 a2)
 	return 0;
 }
 
+// Return a random value to simulate the arcade drum
+uint16_t rand16(void) {
+	uint16_t r = 0;
+	int random;
+	int max_value = 20000; // ~ 90 in I/O test menu
+	int min_value = 10000; // ~ 50 in I/O test menu
+
+	random = rand() % max_value + min_value;
+	r = (unsigned)random;
+
+	return r;
+}
+
 static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 {
 	//info(true, "bnusio_GetAnalogIn a1: %u", a1);
 
 	uint16_t rv = 0;
+	uint16_t rvSim = 0;
+
+	rvSim = rand16();
 
 	if (a1 == 0 && (bool)(*ffbOffset & 0x40))        // Player 1 Drum Rim Left
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 1 && (bool)(*ffbOffset & 0x80))   // Player 1 Drum Center Left
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 2 && (bool)(*ffbOffset & 0x100))  // Player 1 Drum Center Right
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 3 && (bool)(*ffbOffset & 0x200))  // Player 1 Drum Rim Right
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 4 && (bool)(*ffbOffset & 0x400))  // Player 2 Drum Rim Left
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 5 && (bool)(*ffbOffset & 0x800))  // Player 2 Drum Center Left
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 6 && (bool)(*ffbOffset & 0x1000)) // Player 2 Drum Center Right
-		rv = 0xFFFF;
+		rv = rvSim;
 	else if (a1 == 7 && (bool)(*ffbOffset & 0x2000)) // Player 2 Drum Rim Right
-		rv = 0xFFFF;
+		rv = rvSim;
 
 	return rv;
 }


### PR DESCRIPTION
This PR adds a function to randomly generate a value for input sensitivity of the drum. Since the arcade controller is analog, the game uses the raw values to determine a cooldown period. In it's current implementation, the input value sent by OpenParrot is 0xFFFF. Since the value is always the same, the game disregards notes that are close to one another. This is noticeable on drum rolls (especially if you're using a Taiko Force Lv5 controller):

https://user-images.githubusercontent.com/82057235/147324214-8dafac14-bb11-45d3-9e44-231c9b5c63d5.mp4

I added a function to randomly generate a value when a key is pressed. After a bit of testing I found the sweet spot that randomly generates values between ~40 to ~90 in the I/O Test menu:

https://user-images.githubusercontent.com/82057235/147324335-225eb8c5-756e-4c47-a506-be86ef6fe925.mp4

Which results in faster input (~30 more hits in the same roll):

https://user-images.githubusercontent.com/82057235/147324359-6b27f767-2e0a-4333-958c-2faa4d942fbd.mp4

I'm new to C++ so if this implementation seems sloppy, please let me know!
