### PR TITLE
[Taiko no Tatsujin Nijiiro Ver] Only register a hit on rising edge

### DIFF
--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -120,7 +120,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 1 Drum Center Left
-	if (a1 == 1) {
+	else if (a1 == 1) {
 		bool currentBtn = (bool)(*ffbOffset & 0x80);
 
 		if (currentBtn && btnP1CenterL != currentBtn) {
@@ -131,7 +131,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 1 Drum Center Right
-	if (a1 == 2) {
+	else if (a1 == 2) {
 		bool currentBtn = (bool)(*ffbOffset & 0x100);
 
 		if (currentBtn && btnP1CenterR != currentBtn) {
@@ -142,7 +142,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 1 Drum Rim Right
-	if (a1 == 3) {
+	else if (a1 == 3) {
 		bool currentBtn = (bool)(*ffbOffset & 0x200);
 
 		if (currentBtn && btnP1RimR != currentBtn) {
@@ -153,7 +153,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 2 Drum Rim Left
-	if (a1 == 4) {
+	else if (a1 == 4) {
 		bool currentBtn = (bool)(*ffbOffset & 0x400);
 
 		if (currentBtn && btnP2RimL != currentBtn) {
@@ -164,7 +164,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 2 Drum Center Left
-	if (a1 == 5) {
+	else if (a1 == 5) {
 		bool currentBtn = (bool)(*ffbOffset & 0x800);
 
 		if (currentBtn && btnP2CenterL != currentBtn) {
@@ -175,7 +175,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 2 Drum Center Right
-	if (a1 == 6) {
+	else if (a1 == 6) {
 		bool currentBtn = (bool)(*ffbOffset & 0x1000);
 
 		if (currentBtn && btnP2CenterR != currentBtn) {
@@ -186,7 +186,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	}
 
 	// Player 2 Drum Rim Right
-	if (a1 == 7) {
+	else if (a1 == 7) {
 		bool currentBtn = (bool)(*ffbOffset & 0x2000);
 
 		if (currentBtn && btnP2RimR != currentBtn) {

--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -91,7 +91,7 @@ static uint16_t rand16(void) {
 	uint16_t r = 0;
 	int random;
 	int max_value = 20000; // ~ 90 in I/O test menu
-	int min_value = 10000; // ~ 50 in I/O test menu
+	int min_value = 10000; // ~ 30 in I/O test menu
 
 	random = rand() % max_value + min_value;
 	r = (unsigned)random;

--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -9,6 +9,17 @@
 static bool btnTestToggle = false;
 static bool btnTestLast = false;
 static bool btnCoinLast = false;
+
+static bool btnP1RimR = false;
+static bool btnP1CenterR = false;
+static bool btnP1CenterL= false;
+static bool btnP1RimL = false;
+
+static bool btnP2RimR = false;
+static bool btnP2CenterR = false;
+static bool btnP2CenterL = false;
+static bool btnP2RimL = false;
+
 static uint16_t coinCount = 0;
 extern int* ffbOffset;
 
@@ -97,23 +108,94 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 
 	rvSim = rand16();
 
-	if (a1 == 0 && (bool)(*ffbOffset & 0x40))        // Player 1 Drum Rim Left
-		rv = rvSim;
-	else if (a1 == 1 && (bool)(*ffbOffset & 0x80))   // Player 1 Drum Center Left
-		rv = rvSim;
-	else if (a1 == 2 && (bool)(*ffbOffset & 0x100))  // Player 1 Drum Center Right
-		rv = rvSim;
-	else if (a1 == 3 && (bool)(*ffbOffset & 0x200))  // Player 1 Drum Rim Right
-		rv = rvSim;
-	else if (a1 == 4 && (bool)(*ffbOffset & 0x400))  // Player 2 Drum Rim Left
-		rv = rvSim;
-	else if (a1 == 5 && (bool)(*ffbOffset & 0x800))  // Player 2 Drum Center Left
-		rv = rvSim;
-	else if (a1 == 6 && (bool)(*ffbOffset & 0x1000)) // Player 2 Drum Center Right
-		rv = rvSim;
-	else if (a1 == 7 && (bool)(*ffbOffset & 0x2000)) // Player 2 Drum Rim Right
-		rv = rvSim;
+	// Player 1 Drum Rim Left
+	if (a1 == 0) {
+		bool currentBtn = (bool)(*ffbOffset & 0x40);
 
+		if (currentBtn && btnP1RimL != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP1RimL = currentBtn;
+	}
+
+	// Player 1 Drum Center Left
+	if (a1 == 1) {
+		bool currentBtn = (bool)(*ffbOffset & 0x80);
+
+		if (currentBtn && btnP1CenterL != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP1CenterL = currentBtn;
+	}
+
+	// Player 1 Drum Center Right
+	if (a1 == 2) {
+		bool currentBtn = (bool)(*ffbOffset & 0x100);
+
+		if (currentBtn && btnP1CenterR != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP1CenterR = currentBtn;
+	}
+
+	// Player 1 Drum Rim Right
+	if (a1 == 3) {
+		bool currentBtn = (bool)(*ffbOffset & 0x200);
+
+		if (currentBtn && btnP1RimR != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP1RimR = currentBtn;
+	}
+
+	// Player 2 Drum Rim Left
+	if (a1 == 4) {
+		bool currentBtn = (bool)(*ffbOffset & 0x400);
+
+		if (currentBtn && btnP2RimL != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP2RimL = currentBtn;
+	}
+
+	// Player 2 Drum Center Left
+	if (a1 == 5) {
+		bool currentBtn = (bool)(*ffbOffset & 0x800);
+
+		if (currentBtn && btnP2CenterL != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP2CenterL = currentBtn;
+	}
+
+	// Player 2 Drum Center Right
+	if (a1 == 6) {
+		bool currentBtn = (bool)(*ffbOffset & 0x1000);
+
+		if (currentBtn && btnP2CenterR != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP2CenterR = currentBtn;
+	}
+
+	// Player 2 Drum Rim Right
+	if (a1 == 7) {
+		bool currentBtn = (bool)(*ffbOffset & 0x2000);
+
+		if (currentBtn && btnP2RimR != currentBtn) {
+			rv = rvSim;
+		}
+
+		btnP2RimR = currentBtn;
+	}
+	
 	return rv;
 }
 

--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -104,16 +104,13 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	//info(true, "bnusio_GetAnalogIn a1: %u", a1);
 
 	uint16_t rv = 0;
-	uint16_t rvSim = 0;
-
-	rvSim = rand16();
 
 	// Player 1 Drum Rim Left
 	if (a1 == 0) {
 		bool currentBtn = (bool)(*ffbOffset & 0x40);
 
 		if (currentBtn && btnP1RimL != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 		
 		btnP1RimL = currentBtn;
 	}
@@ -123,7 +120,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x80);
 
 		if (currentBtn && btnP1CenterL != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 		
 		btnP1CenterL = currentBtn;
 	}
@@ -133,7 +130,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x100);
 
 		if (currentBtn && btnP1CenterR != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 
 		btnP1CenterR = currentBtn;
 	}
@@ -143,7 +140,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x200);
 
 		if (currentBtn && btnP1RimR != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 
 		btnP1RimR = currentBtn;
 	}
@@ -153,7 +150,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x400);
 
 		if (currentBtn && btnP2RimL != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 
 		btnP2RimL = currentBtn;
 	}
@@ -163,7 +160,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x800);
 
 		if (currentBtn && btnP2CenterL != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 
 		btnP2CenterL = currentBtn;
 	}
@@ -173,7 +170,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x1000);
 
 		if (currentBtn && btnP2CenterR != currentBtn)
-			rv = rvSim;
+			rv = rand16();
 
 		btnP2CenterR = currentBtn;
 	}
@@ -183,7 +180,7 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 		bool currentBtn = (bool)(*ffbOffset & 0x2000);
 
 		if (currentBtn && btnP2RimR != currentBtn) 
-			rv = rvSim;
+			rv = rand16();
 		
 		btnP2RimR = currentBtn;
 	}

--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -87,7 +87,7 @@ static __int64 __fastcall bnusio_DecService(int a1, unsigned __int16 a2)
 }
 
 // Return a random value to simulate the arcade drum
-uint16_t rand16(void) {
+static uint16_t rand16(void) {
 	uint16_t r = 0;
 	int random;
 	int max_value = 20000; // ~ 90 in I/O test menu

--- a/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
+++ b/OpenParrot/src/Functions/Games/BNA1/Taiko.cpp
@@ -112,10 +112,9 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	if (a1 == 0) {
 		bool currentBtn = (bool)(*ffbOffset & 0x40);
 
-		if (currentBtn && btnP1RimL != currentBtn) {
+		if (currentBtn && btnP1RimL != currentBtn) 
 			rv = rvSim;
-		}
-
+		
 		btnP1RimL = currentBtn;
 	}
 
@@ -123,10 +122,9 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 1) {
 		bool currentBtn = (bool)(*ffbOffset & 0x80);
 
-		if (currentBtn && btnP1CenterL != currentBtn) {
+		if (currentBtn && btnP1CenterL != currentBtn) 
 			rv = rvSim;
-		}
-
+		
 		btnP1CenterL = currentBtn;
 	}
 
@@ -134,9 +132,8 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 2) {
 		bool currentBtn = (bool)(*ffbOffset & 0x100);
 
-		if (currentBtn && btnP1CenterR != currentBtn) {
+		if (currentBtn && btnP1CenterR != currentBtn) 
 			rv = rvSim;
-		}
 
 		btnP1CenterR = currentBtn;
 	}
@@ -145,9 +142,8 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 3) {
 		bool currentBtn = (bool)(*ffbOffset & 0x200);
 
-		if (currentBtn && btnP1RimR != currentBtn) {
+		if (currentBtn && btnP1RimR != currentBtn) 
 			rv = rvSim;
-		}
 
 		btnP1RimR = currentBtn;
 	}
@@ -156,9 +152,8 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 4) {
 		bool currentBtn = (bool)(*ffbOffset & 0x400);
 
-		if (currentBtn && btnP2RimL != currentBtn) {
+		if (currentBtn && btnP2RimL != currentBtn) 
 			rv = rvSim;
-		}
 
 		btnP2RimL = currentBtn;
 	}
@@ -167,9 +162,8 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 5) {
 		bool currentBtn = (bool)(*ffbOffset & 0x800);
 
-		if (currentBtn && btnP2CenterL != currentBtn) {
+		if (currentBtn && btnP2CenterL != currentBtn) 
 			rv = rvSim;
-		}
 
 		btnP2CenterL = currentBtn;
 	}
@@ -178,9 +172,8 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 6) {
 		bool currentBtn = (bool)(*ffbOffset & 0x1000);
 
-		if (currentBtn && btnP2CenterR != currentBtn) {
+		if (currentBtn && btnP2CenterR != currentBtn)
 			rv = rvSim;
-		}
 
 		btnP2CenterR = currentBtn;
 	}
@@ -189,10 +182,9 @@ static uint16_t __fastcall bnusio_GetAnalogIn(unsigned __int8 a1)
 	else if (a1 == 7) {
 		bool currentBtn = (bool)(*ffbOffset & 0x2000);
 
-		if (currentBtn && btnP2RimR != currentBtn) {
+		if (currentBtn && btnP2RimR != currentBtn) 
 			rv = rvSim;
-		}
-
+		
 		btnP2RimR = currentBtn;
 	}
 	


### PR DESCRIPTION
My last pull request added analog "emulation", but it broke inputs as they would keep registering a hit every loop if a button was pressed and held (causing double hits and other weirdness).

This PR makes sure the button is only registered as a hit on the rising edge.