### PR TITLE
Test

### DIFF
--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -5,6 +5,7 @@
 #include <Utility/Hooking.Patterns.h>
 #include <thread>
 #ifdef _M_AMD64
+
 #pragma optimize("", off)
 #pragma comment(lib, "Ws2_32.lib")
 
@@ -425,6 +426,7 @@ unsigned int WINAPI Hook_bind(SOCKET s, const sockaddr *addr, int namelen) {
 
 
 unsigned char saveData[0x2000];
+
 // BASE: 0x24E0 
 // Campaing honor data: 2998, save 0xB8
 // Story Mode Honor data: 25F0, save 0x98
@@ -516,10 +518,14 @@ static int SaveGameData()
 	if (!saveOk)
 		return 1;
 
+	// Zero out save data binary
 	memset(saveData, 0, 0x2000);
+
+	// Get the hex address for the start of the save data block
 	uintptr_t value = *(uintptr_t*)(imageBase + 0x1948F10);
 	value = *(uintptr_t*)(value + 0x108);
 	memcpy(saveData, (void *)value, 0x340);
+
 	FILE* file = fopen("openprogress.sav", "wb");
 	fwrite(saveData, 1, 0x2000, file);
 	fclose(file);
@@ -527,6 +533,7 @@ static int SaveGameData()
 	// Car Profile saving
 	memset(carData, 0, 0xFF);
 	memset(carFileName, 0, 0xFF);
+
 	memcpy(carData, (void *)*(uintptr_t*)(*(uintptr_t*)(imageBase + 0x1948F10) + 0x180 + 0xa8 + 0x18), 0xE0);
 	CreateDirectoryA("OpenParrot_Cars", nullptr);
 	if(customCar)
@@ -1150,6 +1157,7 @@ static InitFunction Wmmt5Func([]()
 
 	hookPort = "COM3";
 	imageBase = (uintptr_t)GetModuleHandleA(0);
+
 	MH_Initialize();
 
 	// Hook dongle funcs
@@ -1161,8 +1169,6 @@ static InitFunction Wmmt5Func([]()
 	MH_CreateHookApi(L"hasp_windows_x64_109906.dll", "hasp_logout", Hook_hasp_logout, NULL);
 	MH_CreateHookApi(L"hasp_windows_x64_109906.dll", "hasp_login", Hook_hasp_login, NULL);
 	MH_CreateHookApi(L"WS2_32", "bind", Hook_bind, reinterpret_cast<LPVOID*>(&pbind));
-
-
 
 	GenerateDongleData(isTerminal);
 

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -682,10 +682,12 @@ static void LoadWmmt5CarData()
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
 				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 1);
-				memcpy((void *)(carSaveLocation + 0x34), carData + 0x34, 1);
-				// memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
-				// memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
+				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 1); // Stock Colour
+				memcpy((void *)(carSaveLocation + 0x34), carData + 0x34, 1); // Custom Colour
+				memcpy((void*)(carSaveLocation + 0x38), carData + 0x38, 1); // Rims Type
+				memcpy((void *)(carSaveLocation + 0x3C), carData + 0x3C, 1); // Rims Colour
+				memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 1); // Aero Type
+				memcpy((void *)(carSaveLocation + 0x44), carData + 0x44, 1); // Hood Type
 				// memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
 				// memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
 				// memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -668,8 +668,12 @@ static void LoadWmmt5CarData()
 		}
 	}
 
-	// DEBUG: CREATE FORCE FULL TUNE THREAD
-	CreateThread(0, 0, forceFullTune, 0, 0, 0);
+	// If the force full tune switch is set
+	if (ToBool(config["Tune"]["Force Full Tune"]))
+	{
+		// Create the force full tune thread
+		CreateThread(0, 0, forceFullTune, 0, 0, 0);
+	}
 
 	memset(carFileName, 0, 0xFF);
 	// Load actual car if available

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -697,10 +697,9 @@ static void LoadWmmt5CarData()
 				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 1); // Trunk
 				memcpy((void *)(carSaveLocation + 0x84), carData + 0x80, 1); // Plate Frame
 				memcpy((void *)(carSaveLocation + 0x8A), carData + 0x8A, 1); // Plate Frame Colour
-				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 1); // Power ??
-				memcpy((void *)(carSaveLocation + 0x94), carData + 0x94, 1); // Handling ??
-				// memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
-				// memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
+				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
+				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
+				memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
 				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
 				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
 				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -443,8 +443,7 @@ static DWORD WINAPI forceFullTune(void* pArguments)
 		// Only runs every 16th frame
 		Sleep(16);
 
-		// Get the memory addresses for the car base save, power and handling values
-	
+		// Car save hex address
 		auto carSaveBase = (uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
 		auto powerAddress = (uintptr_t*)(*(uintptr_t*)(carSaveBase) + 0x98);
 		auto handleAddress = (uintptr_t*)(*(uintptr_t*)(carSaveBase) + 0x9C);
@@ -632,28 +631,34 @@ static void LoadWmmt5CarData()
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
 
-				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
-				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
-				memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
-				memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
-				memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
-				memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
-				memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
-				memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
-				memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
-				memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
-				memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
-				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
-				memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
-				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
-				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
-				memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
-				memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
-				memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
-				memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
-				memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
-				memcpy((void *)(carSaveLocation + 0xE0), carData + 0xE0, 8);
+				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
+				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
+				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
+				memcpy((void*)(carSaveLocation + 0x30), carData + 0x30, 1); // Stock Colour
+				memcpy((void*)(carSaveLocation + 0x34), carData + 0x34, 1); // Custom Colour
+				memcpy((void*)(carSaveLocation + 0x38), carData + 0x38, 1); // Rims Type
+				memcpy((void*)(carSaveLocation + 0x3C), carData + 0x3C, 1); // Rims Colour
+				memcpy((void*)(carSaveLocation + 0x40), carData + 0x40, 1); // Aero Type
+				memcpy((void*)(carSaveLocation + 0x44), carData + 0x44, 1); // Hood Type
+				memcpy((void*)(carSaveLocation + 0x50), carData + 0x50, 1); // Wing Type
+				memcpy((void*)(carSaveLocation + 0x54), carData + 0x54, 1); // Mirror Type
+				memcpy((void*)(carSaveLocation + 0x58), carData + 0x58, 1); // Body Sticker Type
+				memcpy((void*)(carSaveLocation + 0x5C), carData + 0x5C, 1); // Body Sticker Variant
+				// memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
+				memcpy((void*)(carSaveLocation + 0x7C), carData + 0x7C, 1); // Neons
+				memcpy((void*)(carSaveLocation + 0x80), carData + 0x80, 1); // Trunk
+				memcpy((void*)(carSaveLocation + 0x84), carData + 0x80, 1); // Plate Frame
+				memcpy((void*)(carSaveLocation + 0x8A), carData + 0x8A, 1); // Plate Frame Colour
+				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
+				memcpy((void*)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
+				memcpy((void*)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
+				memcpy((void*)(carSaveLocation + 0xA4), carData + 0xA4, 1); // Rank
+				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
+				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
+				// memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
+				// memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
+				//memcpy((void *)(carSaveLocation + 0xE0), carData + 0xE0, 8);
 
 				customCar = true;
 			}
@@ -662,6 +667,9 @@ static void LoadWmmt5CarData()
 			return;
 		}
 	}
+
+	// DEBUG: CREATE FORCE FULL TUNE THREAD
+	CreateThread(0, 0, forceFullTune, 0, 0, 0);
 
 	memset(carFileName, 0, 0xFF);
 	// Load actual car if available
@@ -678,6 +686,7 @@ static void LoadWmmt5CarData()
 				fseek(file, 0, SEEK_SET);
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
+
 				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
@@ -700,7 +709,7 @@ static void LoadWmmt5CarData()
 				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
 				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
 				memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
-				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
+				memcpy((void *)(carSaveLocation + 0xA4), carData + 0xA4, 1); // Rank
 				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
 				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
 				// memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -698,7 +698,7 @@ static void LoadWmmt5CarData()
 				memcpy((void *)(carSaveLocation + 0x84), carData + 0x80, 1); // Plate Frame
 				memcpy((void *)(carSaveLocation + 0x8A), carData + 0x8A, 1); // Plate Frame Colour
 				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 1); // Power ??
-				memcpy((void *)(carSaveLocation + 0x94), carData + 0x90, 1); // Handling ??
+				memcpy((void *)(carSaveLocation + 0x94), carData + 0x94, 1); // Handling ??
 				// memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
 				// memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
 				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -678,7 +678,7 @@ static void LoadWmmt5CarData()
 				fseek(file, 0, SEEK_SET);
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
-				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
 				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -697,9 +697,10 @@ static void LoadWmmt5CarData()
 				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 1); // Trunk
 				memcpy((void *)(carSaveLocation + 0x84), carData + 0x80, 1); // Plate Frame
 				memcpy((void *)(carSaveLocation + 0x8A), carData + 0x8A, 1); // Plate Frame Colour
-				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
-				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
-				memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
+				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 1); // Power ??
+				memcpy((void *)(carSaveLocation + 0x94), carData + 0x90, 1); // Handling ??
+				// memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
+				// memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
 				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
 				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
 				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -682,7 +682,8 @@ static void LoadWmmt5CarData()
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
 				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
+				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 1);
+				memcpy((void *)(carSaveLocation + 0x34), carData + 0x34, 1);
 				// memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
 				// memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
 				// memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -681,8 +681,8 @@ static void LoadWmmt5CarData()
 				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
-				memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				// memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
+				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
+				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
 				// memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
 				// memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
 				// memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -632,6 +632,7 @@ static void LoadWmmt5CarData()
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
 
+				/*
 				memcpy((void*)(carSaveLocation + 0x98), carData + 0x98, 0x1); // Power
 				memcpy((void*)(carSaveLocation + 0x9C), carData + 0x9C, 0x1); // Handling
 				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Region
@@ -656,29 +657,31 @@ static void LoadWmmt5CarData()
 				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Vinyl_body_challenge_prefecture
 				memcpy((void*)(carSaveLocation + 0xA4), carData + 0xA4, 0x1); // Rank
 				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Title
+				*/
 
-				//memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
-				//memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
-				//memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
-				//memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
-				//memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				//memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
-				//memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
-				//memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
-				//memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
-				//memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
-				//memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
-				//memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
-				//memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
-				//memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
-				//memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
-				//memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
-				//memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
-				//memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
-				//memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
-				//memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
-				//memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
-				//memcpy((void *)(carSaveLocation + 0xE0), carData + 0xE0, 8);
+				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
+				memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
+				memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
+				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
+				memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
+				memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
+				memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
+				memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
+				memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
+				memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
+				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
+				memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
+				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
+				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
+				memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
+				memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
+				memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
+				memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
+				memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
+				memcpy((void *)(carSaveLocation + 0xE0), carData + 0xE0, 8);
+
 				customCar = true;
 			}
 			loadOk = false;

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -678,10 +678,10 @@ static void LoadWmmt5CarData()
 				fseek(file, 0, SEEK_SET);
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
-				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
 				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
-				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
+				memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
 				// memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
 				// memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
 				// memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -632,33 +632,6 @@ static void LoadWmmt5CarData()
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
 
-				/*
-				memcpy((void*)(carSaveLocation + 0x98), carData + 0x98, 0x1); // Power
-				memcpy((void*)(carSaveLocation + 0x9C), carData + 0x9C, 0x1); // Handling
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Region
-				memcpy((void*)(carSaveLocation + 0x2C), carData + 0x2C, 0x1); // CarID
-				memcpy((void*)(carSaveLocation + 0x30), carData + 0x30, 0x1); // DefaultColor
-				memcpy((void*)(carSaveLocation + 0x34), carData + 0x34, 0x1); // CustomColor
-				memcpy((void*)(carSaveLocation + 0x38), carData + 0x38, 0x1); // Rims
-				memcpy((void*)(carSaveLocation + 0x3C), carData + 0x3C, 0x1); // RimColor
-				memcpy((void*)(carSaveLocation + 0x40), carData + 0x40, 0x1); // Aero
-				memcpy((void*)(carSaveLocation + 0x44), carData + 0x44, 0x1); // Hood
-				memcpy((void*)(carSaveLocation + 0x50), carData + 0x50, 0x1); // Wang
-				memcpy((void*)(carSaveLocation + 0x54), carData + 0x54, 0x1); // Mirror
-				memcpy((void*)(carSaveLocation + 0x58), carData + 0x58, 0x1); // Sticker
-				memcpy((void*)(carSaveLocation + 0x5C), carData + 0x5C, 0x1); // StickerVariant
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // RoofSticker
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // RoofStickerVariant
-				memcpy((void*)(carSaveLocation + 0x7C), carData + 0x7C, 0x1); // Should add neons
-				memcpy((void*)(carSaveLocation + 0x80), carData + 0x80, 0x1); // Trunk
-				memcpy((void*)(carSaveLocation + 0x84), carData + 0x84, 0x1); // PlateFrame
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x4); // PlateNumber
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Vinyl_body_challenge_prefecture_1~15
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Vinyl_body_challenge_prefecture
-				memcpy((void*)(carSaveLocation + 0xA4), carData + 0xA4, 0x1); // Rank
-				// memcpy((void*)(carSaveLocation + 0x), carData + 0x, 0x1); // Title
-				*/
-
 				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
 				memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
@@ -705,26 +678,26 @@ static void LoadWmmt5CarData()
 				fseek(file, 0, SEEK_SET);
 				fread(carData, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBase + 0x1948F10)) + 0x180 + 0xa8 + 0x18);
-				memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
-				memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
-				memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
-				memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
-				memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
-				memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
-				memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
-				memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
-				memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
-				memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
-				memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
-				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
-				memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
-				memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
-				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
-				memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
-				memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
-				memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
-				memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
-				memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
+				// memcpy((void *)(carSaveLocation + 0x08), carData + 0x08, 8);
+				// memcpy((void *)(carSaveLocation + 0x10), carData + 0x10, 8);
+				// memcpy((void *)(carSaveLocation + 0x20), carData + 0x20, 8);
+				// memcpy((void *)(carSaveLocation + 0x28), carData + 0x28, 8);
+				// memcpy((void *)(carSaveLocation + 0x30), carData + 0x30, 8);
+				// memcpy((void *)(carSaveLocation + 0x38), carData + 0x38, 8);
+				// memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 8);
+				// memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
+				// memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
+				// memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
+				// memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
+				// memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
+				// memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
+				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
+				// memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
+				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
+				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
+				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);
+				// memcpy((void *)(carSaveLocation + 0xC8), carData + 0xC8, 8);
+				// memcpy((void *)(carSaveLocation + 0xD8), carData + 0xD8, 8);
 				//memcpy((void *)(carSaveLocation + 0xE0), carData + 0xE0, 8);
 			}
 			fclose(file);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5.cpp
@@ -688,14 +688,18 @@ static void LoadWmmt5CarData()
 				memcpy((void *)(carSaveLocation + 0x3C), carData + 0x3C, 1); // Rims Colour
 				memcpy((void *)(carSaveLocation + 0x40), carData + 0x40, 1); // Aero Type
 				memcpy((void *)(carSaveLocation + 0x44), carData + 0x44, 1); // Hood Type
-				// memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 8);
-				// memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 8);
+				memcpy((void *)(carSaveLocation + 0x50), carData + 0x50, 1); // Wing Type
+				memcpy((void *)(carSaveLocation + 0x54), carData + 0x54, 1); // Mirror Type
+				memcpy((void *)(carSaveLocation + 0x58), carData + 0x58, 1); // Body Sticker Type
+				memcpy((void *)(carSaveLocation + 0x5C), carData + 0x5C, 1); // Body Sticker Variant
 				// memcpy((void *)(carSaveLocation + 0x68), carData + 0x68, 8);
-				// memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); //should add neons
-				// memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 8);
-				// memcpy((void *)(carSaveLocation + 0x88), carData + 0x88, 8);
+				memcpy((void *)(carSaveLocation + 0x7C), carData + 0x7C, 1); // Neons
+				memcpy((void *)(carSaveLocation + 0x80), carData + 0x80, 1); // Trunk
+				memcpy((void *)(carSaveLocation + 0x84), carData + 0x80, 1); // Plate Frame
+				memcpy((void *)(carSaveLocation + 0x8A), carData + 0x8A, 1); // Plate Frame Colour
 				// memcpy((void *)(carSaveLocation + 0x90), carData + 0x90, 8);
-				// memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 8);
+				memcpy((void *)(carSaveLocation + 0x98), carData + 0x98, 1); // Power
+				memcpy((void *)(carSaveLocation + 0x9C), carData + 0x9C, 1); // Handling
 				// memcpy((void *)(carSaveLocation + 0xA0), carData + 0xA0, 8);
 				// memcpy((void *)(carSaveLocation + 0xA8), carData + 0xA8, 8);
 				// memcpy((void *)(carSaveLocation + 0xB8), carData + 0xB8, 8);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
@@ -19,45 +19,9 @@ static bool isFreePlay;
 static bool isEventMode2P;
 static bool isEventMode4P;
 const char *ipaddrdxplus;
-/*
-// Data for IC card, Force Feedback etc OFF.
-unsigned char settingData[408] = {
-	0x1F, 0x8B, 0x08, 0x08, 0x53, 0x6A, 0x8B, 0x5A, 0x00, 0x03, 0x46, 0x73,
-	0x65, 0x74, 0x74, 0x69, 0x6E, 0x67, 0x2E, 0x6C, 0x75, 0x61, 0x00, 0x85,
-	0x93, 0x5B, 0x6F, 0x82, 0x30, 0x14, 0xC7, 0xDF, 0xF9, 0x14, 0x7E, 0x01,
-	0x17, 0x11, 0xE7, 0xDC, 0xC3, 0x1E, 0x14, 0x65, 0x9A, 0x48, 0x66, 0x94,
-	0x68, 0xB2, 0xB7, 0x5A, 0x8E, 0xD2, 0xD8, 0x8B, 0x29, 0xED, 0x16, 0xBF,
-	0xFD, 0x5A, 0xA8, 0x50, 0xB2, 0x65, 0xF2, 0x40, 0xF8, 0xFF, 0xCE, 0x85,
-	0x73, 0x69, 0xFB, 0xFD, 0xFF, 0x9F, 0xC0, 0xBE, 0x7A, 0x25, 0x28, 0x45,
-	0xF8, 0xF9, 0x89, 0x6A, 0x14, 0x3C, 0x08, 0xE8, 0x07, 0x01, 0x8B, 0x11,
-	0x25, 0xC7, 0x25, 0xE2, 0x39, 0x85, 0x18, 0xB8, 0x02, 0xD9, 0x7B, 0xEB,
-	0x45, 0xC3, 0x97, 0xF1, 0xC4, 0x99, 0xA6, 0x18, 0x03, 0x6D, 0x2C, 0x03,
-	0x47, 0x67, 0x12, 0x5D, 0xE0, 0x17, 0x4D, 0x85, 0x12, 0xB2, 0xA1, 0xCF,
-	0x61, 0xE8, 0x78, 0x26, 0x34, 0x2E, 0xD6, 0x70, 0x52, 0x86, 0x0E, 0x07,
-	0xA3, 0x89, 0x8F, 0xB7, 0xE4, 0x5C, 0x58, 0x1E, 0x8E, 0xA2, 0x68, 0xEC,
-	0x1B, 0x32, 0x71, 0xFD, 0x0B, 0xCF, 0x84, 0x52, 0x82, 0xB5, 0x89, 0x04,
-	0xE1, 0x71, 0xA1, 0x15, 0x58, 0xDF, 0x80, 0xCD, 0xF4, 0x2D, 0x46, 0x32,
-	0x8F, 0x45, 0x69, 0x73, 0x46, 0x01, 0x7B, 0x47, 0x0C, 0x9C, 0x1A, 0x5A,
-	0x6F, 0x6E, 0x66, 0xA3, 0x3D, 0x92, 0x68, 0x4A, 0x63, 0xA1, 0x65, 0x79,
-	0x67, 0x23, 0xC3, 0x24, 0xC0, 0x86, 0xA2, 0x5B, 0x9D, 0x72, 0x83, 0x8F,
-	0xAB, 0xBC, 0x6E, 0x72, 0x85, 0x6D, 0xF2, 0xED, 0xB7, 0xAF, 0xF6, 0xC0,
-	0xF3, 0xFB, 0x10, 0xD2, 0xB3, 0x6F, 0x4F, 0x84, 0xC4, 0x90, 0x00, 0xE4,
-	0x47, 0x84, 0x2F, 0x35, 0x3A, 0x10, 0x5E, 0x4E, 0x79, 0xBE, 0x05, 0x86,
-	0xCC, 0x57, 0x9D, 0x7F, 0xF1, 0x65, 0x06, 0x96, 0x8A, 0x1C, 0x6A, 0x97,
-	0x46, 0xCE, 0x49, 0x55, 0x8F, 0x8F, 0x4C, 0xA1, 0xDC, 0xD5, 0x18, 0x53,
-	0x51, 0x42, 0x76, 0xBB, 0x82, 0x6B, 0xCC, 0xCA, 0x9D, 0xE6, 0x46, 0xBD,
-	0x8E, 0x9D, 0x4C, 0x45, 0x47, 0x66, 0x1A, 0x7C, 0x79, 0x80, 0xBC, 0x63,
-	0x2D, 0xB4, 0x2F, 0x13, 0x49, 0x7C, 0xB9, 0x43, 0xCA, 0x97, 0xF3, 0x6A,
-	0x36, 0x56, 0x56, 0x2B, 0xD9, 0x20, 0x0E, 0xB4, 0x2E, 0xD5, 0x8E, 0x7B,
-	0x2F, 0xAC, 0x08, 0x8D, 0x9A, 0x2A, 0x25, 0x11, 0x56, 0x2D, 0xF8, 0x38,
-	0x9D, 0x28, 0xE1, 0xD0, 0x76, 0x6B, 0xD2, 0xE1, 0x8B, 0xA1, 0xE6, 0xD0,
-	0xD6, 0x20, 0x23, 0x0C, 0x3E, 0x05, 0xBF, 0xB7, 0x66, 0x77, 0x6F, 0x91,
-	0xF9, 0xE3, 0xDA, 0x1D, 0x14, 0xCF, 0x69, 0x69, 0x16, 0xD7, 0x04, 0x4F,
-	0x5A, 0x9E, 0x12, 0xEE, 0xE7, 0xDC, 0x69, 0xC6, 0x40, 0x5A, 0x63, 0x27,
-	0xA0, 0x63, 0xE9, 0x86, 0x3C, 0xBC, 0x37, 0xD5, 0x4D, 0x5B, 0x7C, 0x24,
-	0x8F, 0x3D, 0x7F, 0x00, 0x10, 0x1E, 0x34, 0xD9, 0xB5, 0x03, 0x00, 0x00
-};
-*/
+
+// MUST DISABLE IC CARD, FFB MANUALLY N MT5DX+
+
 // FOR FREEPLAY
 unsigned char dxpterminalPackage1_Free[79] = {
 	0x01, 0x04, 0x4B, 0x00, 0x12, 0x14, 0x0A, 0x00, 0x10, 0x04, 0x18, 0x00,
@@ -462,7 +426,7 @@ static DWORD WINAPI forceFullTune(void* pArguments)
 // **** String Variables
 
 // Debugging event log file
-std::string logfile = "wmmt5dxp_errors.txt";
+std::string logfileDxp = "wmmt5dxp_errors.txt";
 
 // writeLog(filename: String, message: String): Int
 // Given a filename string and a message string, appends
@@ -486,29 +450,27 @@ static int writeLog(std::string filename, std::string message)
 }
 
 static bool saveOk = false;
-unsigned char carDatadxp[0xFF];
+unsigned char carDataDxp[0xFF];
 static int SaveOk()
 {
 	saveOk = true;
 	return 1;
 }
 
-char carFileNamedxp[0xFF];
-bool loadOkdxp = false;
-bool customCardxp = false;
+char carFileNameDxp[0xFF];
+bool loadOkDxp = false;
+bool customCarDxp = false;
 
-static void saveMileagedxp()
+static void saveMileage()
 {
-	
-	//Mileage Write to "GAME/mileage.dat"
 	auto mileageLocation = (uintptr_t*)(*(uintptr_t*)(imageBasedxplus + 0x1F7D578) + 0x280);
-	//try this maybe, casting to int probably not right/not gonna work
+
 	FILE* tempFile = fopen("mileage.dat", "wb");
 	fwrite(mileageLocation, 1, sizeof(mileageLocation), tempFile);
 	fclose(tempFile);
 }
 
-static void LoadMileagedxp()
+static void LoadMileage()
 {
 	
 	memset(mileDatadxp, 0, 0x08);
@@ -533,7 +495,7 @@ static int SaveGameData()
 	if (!saveOk)
 		return 1;
 
-	writeLog(logfile, "[DEBUG] Saving game data ...\n");
+	writeLog(logfileDxp, "[DEBUG] Saving game data ...\n");
 
 	// Address where player save data starts
 	uintptr_t saveDataBase = *(uintptr_t*)(imageBasedxplus + 0x1F7D578);
@@ -542,59 +504,59 @@ static int SaveGameData()
 
 	// Zero out save data binary
 	memset(saveDatadxp, 0, 0x2000);
-	writeLog(logfile, "[DEBUG] MEMSET OK\n");
+	writeLog(logfileDxp, "[DEBUG] MEMSET OK\n");
 
 	// Address where the player story data starts
 	uintptr_t storySaveBase = *(uintptr_t*)(saveDataBase + 0x108);
 
-	writeLog(logfile, "[DEBUG] VALUE OK\n");
+	writeLog(logfileDxp, "[DEBUG] VALUE OK\n");
 
 	// Copy 340 nibbles to saveDatadxp from the story save data index
 	memcpy(saveDatadxp, (void*)storySaveBase, 0x340);
-	writeLog(logfile, "[DEBUG] MEMCPY OK\n");
+	writeLog(logfileDxp, "[DEBUG] MEMCPY OK\n");
 
 	// Open the OpenProgress save file binary
 	FILE* file = fopen("openprogress.sav", "wb");
-	writeLog(logfile, "[DEBUG] FOPEN OK\n");
+	writeLog(logfileDxp, "[DEBUG] FOPEN OK\n");
 
 	// Write the full size of the saveDatadxp array
 	// (2000 nibbles) to the openprogress.sav file, 
 	// overwriting existing contents.
 	fwrite(saveDatadxp, 1, 0x2000, file);
-	writeLog(logfile, "[DEBUG] FWRITE OK\n");
+	writeLog(logfileDxp, "[DEBUG] FWRITE OK\n");
 
 	// Close the openprogress file
 	fclose(file);
-	writeLog(logfile, "[DEBUG] FCLOSE OK\n");
+	writeLog(logfileDxp, "[DEBUG] FCLOSE OK\n");
 
-	writeLog(logfile, "[DEBUG] STORY SAVE OK\n");
+	writeLog(logfileDxp, "[DEBUG] STORY SAVE OK\n");
 
 	// Car Profile saving
-	memset(carDatadxp, 0, 0xFF);
-	memset(carFileNamedxp, 0, 0xFF);
+	memset(carDataDxp, 0, 0xFF);
+	memset(carFileNameDxp, 0, 0xFF);
 
 	//new multilevel
 	uintptr_t carSaveBase = *(uintptr_t*)(saveDataBase + 0x268);
 
-	memcpy(carDatadxp + 0x00, (void*)(carSaveBase + 0x0), 0xFF); //dumps whole region
+	memcpy(carDataDxp + 0x00, (void*)(carSaveBase + 0x0), 0xFF); //dumps whole region
 
 
 	CreateDirectoryA("OpenParrot_Cars", nullptr);
 
-	if (customCardxp)
+	if (customCarDxp)
 	{
-		sprintf(carFileNamedxp, ".\\OpenParrot_Cars\\custom.car");
+		sprintf(carFileNameDxp, ".\\OpenParrot_Cars\\custom.car");
 	}
 	else
 	{
-		sprintf(carFileNamedxp, ".\\OpenParrot_Cars\\%08X.car", *(DWORD*)(*(uintptr_t*)(*(uintptr_t*)(imageBasedxplus + 0x1F7D578) + 0x268) + 0x34));
+		sprintf(carFileNameDxp, ".\\OpenParrot_Cars\\%08X.car", *(DWORD*)(*(uintptr_t*)(*(uintptr_t*)(imageBasedxplus + 0x1F7D578) + 0x268) + 0x34));
 	}
 
-	FILE* carFile = fopen(carFileNamedxp, "wb");
-	fwrite(carDatadxp, 1, 0xFF, carFile);
+	FILE* carFile = fopen(carFileNameDxp, "wb");
+	fwrite(carDataDxp, 1, 0xFF, carFile);
 	fclose(carFile);
 
-	saveMileagedxp();
+	saveMileage();
 
 	saveOk = false;
 	return 1;
@@ -664,7 +626,7 @@ static int LoadGameData()
 			memcpy((void *)(storyOffset), saveDatadxp + 0x2B8, 0x88);
 			storyOffset -= 0x2B8;
 
-			loadOkdxp = true;
+			loadOkDxp = true;
 		}
 		fclose(file);
 	}
@@ -674,24 +636,24 @@ static int LoadGameData()
 
 
 
-static void LoadWmmt5CarData()
+static void LoadWmmt5carDataDxp()
 {
 	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-//	if (!loadOkdxp)
+//	if (!loadOkDxp)
 //		return;
-	customCardxp = false;
-	memset(carDatadxp, 0, 0xFF);
-	memset(carFileNamedxp, 0, 0xFF);
+	customCarDxp = false;
+	memset(carDataDxp, 0, 0xFF);
+	memset(carFileNameDxp, 0, 0xFF);
 	CreateDirectoryA("OpenParrot_Cars", nullptr);
 
-	LoadMileagedxp();
+	LoadMileage();
 
 	// check for custom car
-	sprintf(carFileNamedxp, ".\\OpenParrot_Cars\\custom.car");
-	if (FileExists(carFileNamedxp))
+	sprintf(carFileNameDxp, ".\\OpenParrot_Cars\\custom.car");
+	if (FileExists(carFileNameDxp))
 	{
-		FILE* file = fopen(carFileNamedxp, "rb");
+		FILE* file = fopen(carFileNameDxp, "rb");
 		if (file)
 		{
 			fseek(file, 0, SEEK_END);
@@ -699,36 +661,36 @@ static void LoadWmmt5CarData()
 			if (fsize == 0xFF)
 			{
 				fseek(file, 0, SEEK_SET);
-				fread(carDatadxp, fsize, 1, file);
+				fread(carDataDxp, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBasedxplus + 0x1F7D578)) + 0x268);
-				memcpy((void*)(carSaveLocation + 0xAC), carDatadxp + 0xAC, 0x1); //power
-				memcpy((void*)(carSaveLocation + 0xB8), carDatadxp + 0xB8, 0x1); //handling
-				memcpy((void*)(carSaveLocation + 0x28), carDatadxp + 0x28, 0x1); //region
-				memcpy((void*)(carSaveLocation + 0x34), carDatadxp + 0x34, 0x1); //carID
-				memcpy((void*)(carSaveLocation + 0x38), carDatadxp + 0x38, 0x1); //defaultColor
-				memcpy((void*)(carSaveLocation + 0x3C), carDatadxp + 0x3C, 0x1); //customColor
-				memcpy((void*)(carSaveLocation + 0x40), carDatadxp + 0x40, 0x1); //rims
-				memcpy((void*)(carSaveLocation + 0x44), carDatadxp + 0x44, 0x1); //rimColor
-				memcpy((void*)(carSaveLocation + 0x48), carDatadxp + 0x48, 0x1); //aero
-				memcpy((void*)(carSaveLocation + 0x4C), carDatadxp + 0x4C, 0x1); //hood
-				memcpy((void*)(carSaveLocation + 0x58), carDatadxp + 0x58, 0x1); //wang
-				memcpy((void*)(carSaveLocation + 0x5C), carDatadxp + 0x5C, 0x1); //mirror
-				memcpy((void*)(carSaveLocation + 0x60), carDatadxp + 0x60, 0x1); //sticker
-				memcpy((void*)(carSaveLocation + 0x64), carDatadxp + 0x64, 0x1); //stickerVariant
-				memcpy((void*)(carSaveLocation + 0x88), carDatadxp + 0x88, 0x1); //roofSticker
-				memcpy((void*)(carSaveLocation + 0x8C), carDatadxp + 0x8C, 0x1); //roofStickerVariant
-				memcpy((void*)(carSaveLocation + 0x90), carDatadxp + 0x90, 0x1); //neon
-				memcpy((void*)(carSaveLocation + 0x94), carDatadxp + 0x94, 0x1); //trunk
-				memcpy((void*)(carSaveLocation + 0x98), carDatadxp + 0x98, 0x1); //plateFrame
-				memcpy((void*)(carSaveLocation + 0xA0), carDatadxp + 0xA0, 0x4); //plateNumber
-				memcpy((void*)(carSaveLocation + 0xA4), carDatadxp + 0xA4, 0x1); //vinyl_body_challenge_prefecture_1~15
-				memcpy((void*)(carSaveLocation + 0xA8), carDatadxp + 0xA8, 0x1); //vinyl_body_challenge_prefecture
-				memcpy((void*)(carSaveLocation + 0xBC), carDatadxp + 0xBC, 0x1); //rank
-				memcpy((void*)(carSaveLocation + 0xF0), carDatadxp + 0xF0, 0x1); //title??
+				memcpy((void*)(carSaveLocation + 0xAC), carDataDxp + 0xAC, 0x1); //power
+				memcpy((void*)(carSaveLocation + 0xB8), carDataDxp + 0xB8, 0x1); //handling
+				memcpy((void*)(carSaveLocation + 0x28), carDataDxp + 0x28, 0x1); //region
+				memcpy((void*)(carSaveLocation + 0x34), carDataDxp + 0x34, 0x1); //carID
+				memcpy((void*)(carSaveLocation + 0x38), carDataDxp + 0x38, 0x1); //defaultColor
+				memcpy((void*)(carSaveLocation + 0x3C), carDataDxp + 0x3C, 0x1); //customColor
+				memcpy((void*)(carSaveLocation + 0x40), carDataDxp + 0x40, 0x1); //rims
+				memcpy((void*)(carSaveLocation + 0x44), carDataDxp + 0x44, 0x1); //rimColor
+				memcpy((void*)(carSaveLocation + 0x48), carDataDxp + 0x48, 0x1); //aero
+				memcpy((void*)(carSaveLocation + 0x4C), carDataDxp + 0x4C, 0x1); //hood
+				memcpy((void*)(carSaveLocation + 0x58), carDataDxp + 0x58, 0x1); //wang
+				memcpy((void*)(carSaveLocation + 0x5C), carDataDxp + 0x5C, 0x1); //mirror
+				memcpy((void*)(carSaveLocation + 0x60), carDataDxp + 0x60, 0x1); //sticker
+				memcpy((void*)(carSaveLocation + 0x64), carDataDxp + 0x64, 0x1); //stickerVariant
+				memcpy((void*)(carSaveLocation + 0x88), carDataDxp + 0x88, 0x1); //roofSticker
+				memcpy((void*)(carSaveLocation + 0x8C), carDataDxp + 0x8C, 0x1); //roofStickerVariant
+				memcpy((void*)(carSaveLocation + 0x90), carDataDxp + 0x90, 0x1); //neon
+				memcpy((void*)(carSaveLocation + 0x94), carDataDxp + 0x94, 0x1); //trunk
+				memcpy((void*)(carSaveLocation + 0x98), carDataDxp + 0x98, 0x1); //plateFrame
+				memcpy((void*)(carSaveLocation + 0xA0), carDataDxp + 0xA0, 0x4); //plateNumber
+				memcpy((void*)(carSaveLocation + 0xA4), carDataDxp + 0xA4, 0x1); //vinyl_body_challenge_prefecture_1~15
+				memcpy((void*)(carSaveLocation + 0xA8), carDataDxp + 0xA8, 0x1); //vinyl_body_challenge_prefecture
+				memcpy((void*)(carSaveLocation + 0xBC), carDataDxp + 0xBC, 0x1); //rank
+				memcpy((void*)(carSaveLocation + 0xF0), carDataDxp + 0xF0, 0x1); //title??
 
-				customCardxp = true;
+				customCarDxp = true;
 			}
-			loadOkdxp = false;
+			loadOkDxp = false;
 			fclose(file);
 			return;
 		}
@@ -738,12 +700,12 @@ static void LoadWmmt5CarData()
 		CreateThread(0, 0, forceFullTune, 0, 0, 0);
 	}
 
-	memset(carFileNamedxp, 0, 0xFF);
+	memset(carFileNameDxp, 0, 0xFF);
 	// Load actual car if available
-	sprintf(carFileNamedxp, ".\\OpenParrot_Cars\\%08X.car", *(DWORD*)(*(uintptr_t*)(*(uintptr_t*)(imageBasedxplus + 0x1F7D578) + 0x268) + 0x34));
-	if(FileExists(carFileNamedxp))
+	sprintf(carFileNameDxp, ".\\OpenParrot_Cars\\%08X.car", *(DWORD*)(*(uintptr_t*)(*(uintptr_t*)(imageBasedxplus + 0x1F7D578) + 0x268) + 0x34));
+	if(FileExists(carFileNameDxp))
 	{
-		FILE* file = fopen(carFileNamedxp, "rb");
+		FILE* file = fopen(carFileNameDxp, "rb");
 		if (file)
 		{
 			fseek(file, 0, SEEK_END);
@@ -751,42 +713,42 @@ static void LoadWmmt5CarData()
 			if (fsize == 0xFF)
 			{	
 				fseek(file, 0, SEEK_SET);
-				fread(carDatadxp, fsize, 1, file);
+				fread(carDataDxp, fsize, 1, file);
 				uintptr_t carSaveLocation = *(uintptr_t*)((*(uintptr_t*)(imageBasedxplus + 0x1F7D578)) + 0x268);
-				memcpy((void*)(carSaveLocation + 0xAC), carDatadxp + 0xAC, 0x1); //power
-				memcpy((void*)(carSaveLocation + 0xB8), carDatadxp + 0xB8, 0x1); //handling
-				memcpy((void*)(carSaveLocation + 0x28), carDatadxp + 0x28, 0x1); //region
-				memcpy((void*)(carSaveLocation + 0x34), carDatadxp + 0x34, 0x1); //carID
-				memcpy((void*)(carSaveLocation + 0x38), carDatadxp + 0x38, 0x1); //defaultColor
-				memcpy((void*)(carSaveLocation + 0x3C), carDatadxp + 0x3C, 0x1); //customColor
-				memcpy((void*)(carSaveLocation + 0x40), carDatadxp + 0x40, 0x1); //rims
-				memcpy((void*)(carSaveLocation + 0x44), carDatadxp + 0x44, 0x1); //rimColor
-				memcpy((void*)(carSaveLocation + 0x48), carDatadxp + 0x48, 0x1); //aero
-				memcpy((void*)(carSaveLocation + 0x4C), carDatadxp + 0x4C, 0x1); //hood
-				memcpy((void*)(carSaveLocation + 0x58), carDatadxp + 0x58, 0x1); //wang
-				memcpy((void*)(carSaveLocation + 0x5C), carDatadxp + 0x5C, 0x1); //mirror
-				memcpy((void*)(carSaveLocation + 0x60), carDatadxp + 0x60, 0x1); //sticker
-				memcpy((void*)(carSaveLocation + 0x64), carDatadxp + 0x64, 0x1); //stickerVariant
-				memcpy((void*)(carSaveLocation + 0x88), carDatadxp + 0x88, 0x1); //roofSticker
-				memcpy((void*)(carSaveLocation + 0x8C), carDatadxp + 0x8C, 0x1); //roofStickerVariant
-				memcpy((void*)(carSaveLocation + 0x90), carDatadxp + 0x90, 0x1); //neon
-				memcpy((void*)(carSaveLocation + 0x94), carDatadxp + 0x94, 0x1); //trunk
-				memcpy((void*)(carSaveLocation + 0x98), carDatadxp + 0x98, 0x1); //plateFrame
-				memcpy((void*)(carSaveLocation + 0xA0), carDatadxp + 0xA0, 0x4); //plateNumber
-				memcpy((void*)(carSaveLocation + 0xA4), carDatadxp + 0xA4, 0x1); //vinyl_body_challenge_prefecture_1~15
-				memcpy((void*)(carSaveLocation + 0xA8), carDatadxp + 0xA8, 0x1); //vinyl_body_challenge_prefecture
-				memcpy((void*)(carSaveLocation + 0xBC), carDatadxp + 0xBC, 0x1); //rank
-				memcpy((void*)(carSaveLocation + 0xF0), carDatadxp + 0xF0, 0x1); //title??
+				memcpy((void*)(carSaveLocation + 0xAC), carDataDxp + 0xAC, 0x1); //power
+				memcpy((void*)(carSaveLocation + 0xB8), carDataDxp + 0xB8, 0x1); //handling
+				memcpy((void*)(carSaveLocation + 0x28), carDataDxp + 0x28, 0x1); //region
+				memcpy((void*)(carSaveLocation + 0x34), carDataDxp + 0x34, 0x1); //carID
+				memcpy((void*)(carSaveLocation + 0x38), carDataDxp + 0x38, 0x1); //defaultColor
+				memcpy((void*)(carSaveLocation + 0x3C), carDataDxp + 0x3C, 0x1); //customColor
+				memcpy((void*)(carSaveLocation + 0x40), carDataDxp + 0x40, 0x1); //rims
+				memcpy((void*)(carSaveLocation + 0x44), carDataDxp + 0x44, 0x1); //rimColor
+				memcpy((void*)(carSaveLocation + 0x48), carDataDxp + 0x48, 0x1); //aero
+				memcpy((void*)(carSaveLocation + 0x4C), carDataDxp + 0x4C, 0x1); //hood
+				memcpy((void*)(carSaveLocation + 0x58), carDataDxp + 0x58, 0x1); //wang
+				memcpy((void*)(carSaveLocation + 0x5C), carDataDxp + 0x5C, 0x1); //mirror
+				memcpy((void*)(carSaveLocation + 0x60), carDataDxp + 0x60, 0x1); //sticker
+				memcpy((void*)(carSaveLocation + 0x64), carDataDxp + 0x64, 0x1); //stickerVariant
+				memcpy((void*)(carSaveLocation + 0x88), carDataDxp + 0x88, 0x1); //roofSticker
+				memcpy((void*)(carSaveLocation + 0x8C), carDataDxp + 0x8C, 0x1); //roofStickerVariant
+				memcpy((void*)(carSaveLocation + 0x90), carDataDxp + 0x90, 0x1); //neon
+				memcpy((void*)(carSaveLocation + 0x94), carDataDxp + 0x94, 0x1); //trunk
+				memcpy((void*)(carSaveLocation + 0x98), carDataDxp + 0x98, 0x1); //plateFrame
+				memcpy((void*)(carSaveLocation + 0xA0), carDataDxp + 0xA0, 0x4); //plateNumber
+				memcpy((void*)(carSaveLocation + 0xA4), carDataDxp + 0xA4, 0x1); //vinyl_body_challenge_prefecture_1~15
+				memcpy((void*)(carSaveLocation + 0xA8), carDataDxp + 0xA8, 0x1); //vinyl_body_challenge_prefecture
+				memcpy((void*)(carSaveLocation + 0xBC), carDataDxp + 0xBC, 0x1); //rank
+				memcpy((void*)(carSaveLocation + 0xF0), carDataDxp + 0xF0, 0x1); //title??
 			}
 			fclose(file);
 		}
 	}
-	loadOkdxp = false;
+	loadOkDxp = false;
 }
 
 static void loadCar()
 {
-	std::thread t1(LoadWmmt5CarData);
+	std::thread t1(LoadWmmt5carDataDxp);
 	t1.detach();
 }
 
@@ -994,7 +956,7 @@ static DWORD WINAPI SpamMulticast(LPVOID)
 // of required subprocesses.
 static InitFunction Wmmt5Func([]()
 {
-	writeLog(logfile, "[DEBUG] Starting emulation ...\n");
+	writeLog(logfileDxp, "[DEBUG] Starting emulation ...\n");
 
 	// Records if terminal mode is enabled
 	bool isTerminal = false;

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
@@ -441,10 +441,8 @@ static DWORD WINAPI forceFT(void* pArguments)
 			injector::WriteMemory<uint8_t>(powerAddress, 0x10, true);
 			injector::WriteMemory<uint8_t>(handleAddress, 0x10, true);
 		}
-		else // Car is already fully tuned
-		{
-			// Don't do anything
-		}
+
+		// Otherwise, don't do anything :)
 	}
 }
 

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
@@ -665,88 +665,10 @@ static int LoadGameData()
 			storyOffset -= 0x2B8;
 
 			loadOkdxp = true;
-
-			// Time Attack
-
-			//[[[[magic_rva]+108]+340]+50]
-
-			//value += 0x24E0;
-			// First chunk
-			//memcpy((void *)(value + 0x16), saveData + 0x16, 0x28);
-			////
-			//memcpy((void *)(value + 0x40), saveData + 0x40, 0x18);
-			////
-			//memcpy((void *)(value + 0x60), saveData + 0x60, 0x20);
-			////
-			//memcpy((void *)(value + 0x90), saveData + 0x90, 0x28);
-			////
-			//memcpy((void *)(value + 0xC0), saveData + 0xC0, 0x10);
-			////
-			//memcpy((void *)(value + 0xD8), saveData + 0xD8, 0x28); // OK
-			////
-			//memcpy((void *)(value + 0x110), saveData + 0x110, 0x98);
-			////
-			//memcpy((void *)(value + 0x1B8), saveData + 0x1B8, 0x48);
-			////
-			//memcpy((void *)(value + 0x208), saveData + 0x208, 0x28);
-			////
-			//memcpy((void *)(value + 0x240), saveData + 0x240, 0x68);
-			////
-			//memcpy((void *)(value + 0x2B8), saveData + 0x2B8, 0x88);
-			//
-			//memcpy((void *)(value + 0x370), saveData + 0x370, 0x10);
-			////
-			//memcpy((void *)(value + 0x388), saveData + 0x388, 0x90);
-			////
-			//memcpy((void *)(value + 0x420), saveData + 0x420, 0x18);
-			////
-			//memcpy((void *)(value + 0x440), saveData + 0x440, 0x18);
-			////
-			//memcpy((void *)(value + 0x460), saveData + 0x460, 0x48);
-			////
-			//memcpy((void *)(value + 0x4B8), saveData + 0x4B8, 0xB8);
-			////
-			//memcpy((void *)(value + 0x578), saveData + 0x578, 0x08);
-			////
-			//memcpy((void *)(value + 0x5A8), saveData + 0x5A8, 0x68);
-			////
-			//memcpy((void *)(value + 0x628), saveData + 0x628, 0x48);
-			////
-			//memcpy((void *)(value + 0x688), saveData + 0x688, 0x48);
-			////
-			//memcpy((void *)(value + 0x6E8), saveData + 0x6E8, 0xA8);
-			////
-			//memcpy((void *)(value + 0x7A0), saveData + 0x7A0, 0x10);
-			////
-			//memcpy((void *)(value + 0x7B8), saveData + 0x7B8, 0x28);
-			////
-			//memcpy((void *)(value + 0x7E8), saveData + 0x7E8, 0x10);
-			////
-			////memcpy((void *)(value + 0x800), saveData + 0x800, 0x48); // Problem
-			//////
-			//memcpy((void *)(value + 0x850), saveData + 0x850, 0x08);
-			//
-			//memcpy((void *)(value + 0x860), saveData + 0x860, 0x08);
-			//////
-			//memcpy((void *)(value + 0x870), saveData + 0x870, 0x18);
-			////
-			//memcpy((void *)(value + 0x890), saveData + 0x890, 0x40);
-			////
-			//memcpy((void *)(value + 0x8E0), saveData + 0x8E0, 0x10);
-			////
-			//memcpy((void *)(value + 0x8F8), saveData + 0x8F8, 0x28);
-			////
-			//memcpy((void *)(value + 0x928), saveData + 0x928, 0x10);
-			////
-			//memcpy((void *)(value + 0x940), saveData + 0x940, 0x48); // Problem
 		}
 		fclose(file);
 	}
-	//LoadStoryData();
-	//LoadCampaingHonorData();
-	//LoadStoryModeNoLoseHonorData();
-	//LoadOtherHonorData();
-	//LoadCampaingHonorData2();
+
 	return 1;
 }
 
@@ -1066,63 +988,31 @@ static DWORD WINAPI SpamMulticast(LPVOID)
 	}
 }
 
-/*
-extern int* ffbOffset;
-extern int* ffbOffset2;
-extern int* ffbOffset3;
-extern int* ffbOffset4;
-
-DWORD WINAPI Wmmt5FfbCollector(void* ctx)
-{
-	uintptr_t imageBase = (uintptr_t)GetModuleHandleA(0);
-	while (true)
-	{
-		*ffbOffset = *(DWORD *)(imageBase + 0x196F188);
-		*ffbOffset2 = *(DWORD *)(imageBase + 0x196F18c);
-		*ffbOffset3 = *(DWORD *)(imageBase + 0x196F190);
-		*ffbOffset4 = *(DWORD *)(imageBase + 0x196F194);
-		Sleep(10);
-	}
-}*/
-
+// Wmmt5Func([]()): InitFunction
+// Performs the initial startup tasks for 
+// maximum tune 5, including the starting 
+// of required subprocesses.
 static InitFunction Wmmt5Func([]()
-{/*
-	FILE* fileF = _wfopen(L"Fsetting.lua.gz", L"r");
-	if (fileF == NULL)
-	{
-		FILE* settingsF = _wfopen(L"Fsetting.lua.gz", L"wb");
-		fwrite(settingData, 1, sizeof(settingData), settingsF);
-		fclose(settingsF);
-	}
-	else
-	{
-		fclose(fileF);
-	}
-
-	FILE* fileG = _wfopen(L"Gsetting.lua.gz", L"r");
-	if (fileG == NULL)
-	{
-		FILE* settingsG = _wfopen(L"Gsetting.lua.gz", L"wb");
-		fwrite(settingData, 1, sizeof(settingData), settingsG);
-		fclose(settingsG);
-	}
-	else
-	{
-		fclose(fileG);
-	}*/
-
+{
 	writeLog(logfile, "[DEBUG] Starting emulation ...\n");
 
+	// Records if terminal mode is enabled
 	bool isTerminal = false;
+
+	// If terminal mode is set in the general settings
 	if (ToBool(config["General"]["TerminalMode"]))
 	{
+		// Terminal mode is set
 		isTerminal = true;
 	}
 	
+	// Get the network adapter ip address from the general settings
 	std::string networkip = config["General"]["NetworkAdapterIP"];
+
+	// If the ip address is not blank
 	if (!networkip.empty())
 	{
-		//strcpy(ipaddr, networkip.c_str());
+		// Overwrite the default ip address
 		ipaddrdxplus = networkip.c_str();
 	}
 
@@ -1140,12 +1030,9 @@ static InitFunction Wmmt5Func([]()
 	MH_CreateHookApi(L"hasp_windows_x64_106482.dll", "hasp_logout", dxpHook_hasp_logout, NULL);
 	MH_CreateHookApi(L"hasp_windows_x64_106482.dll", "hasp_login", dxpHook_hasp_login, NULL);
 
-
-
 	GenerateDongleDataDxp(isTerminal);
 
-
-	//prevents game from setting time, thanks pockywitch!
+	// Prevents game from setting time, thanks pockywitch!
 	MH_CreateHookApi(L"KERNEL32", "SetSystemTime", Hook_SetSystemTime, reinterpret_cast<LPVOID*>(&pSetSystemTime));
 
 	// Patch some check TEMP DISABLE AS WELL OVER HERE
@@ -1183,81 +1070,35 @@ static InitFunction Wmmt5Func([]()
 	// Patch some call
 	// 45 33 C0 BA 65 09 00 00 48 8D 4D B0 E8 ?? ?? ?? ?? 48 8B 08
 	// FOUND ON 21, 10, 1
-	//injector::MakeNOP(imageBase + 0x7DADED, 5);
-	//THIS injector::MakeNOP(hook::get_pattern("45 33 C0 BA 65 09 00 00 48 8D 4D B0 E8 ? ? ? ? 48 8B 08", 12), 5);
 
 	{
 		// 199AE18 TIME OFFSET RVA temp disable ALL JNZ PATCH
 
 		auto location = hook::get_pattern<char>("41 3B C7 74 0E 48 8D 8F B8 00 00 00 BA F6 01 00 00 EB 6E 48 8D 8F A0 00 00 00");
+		
 		// Patch some jnz
 		// 41 3B C7 74 0E 48 8D 8F B8 00 00 00 BA F6 01 00 00 EB 6E 48 8D 8F A0 00 00 00
 		// FOUND ON 21, 10, 1
-		//injector::WriteMemory<uint8_t>(imageBase + 0x943F52, 0xEB, true);
 		injector::WriteMemory<uint8_t>(location + 3, 0xEB, true); //patches content router (doomer)
 
 		// Skip some jnz
-		//injector::MakeNOP(imageBase + 0x943F71, 2);
 		injector::MakeNOP(location + 0x22, 2); //patches ip addr error again (doomer)
 
 		// Skip some jnz
-		//injector::MakeNOP(imageBase + 0x943F82, 2);
 		injector::MakeNOP(location + 0x33, 2); //patches ip aaddr error(doomer)
 	}
 
-	// Skip DebugBreak on MFStartup fail
-	// 48 83 EC 28 33 D2 B9 70 00 02 00 E8 ?? ?? ?? ?? 85 C0 79 06
-	// FOUND on 21, 1
+	// Terminal mode is off
+	if (!isTerminal)
 	{
-		/*
-		auto location = hook::get_pattern<char>("48 83 EC 28 33 D2 B9 70 00 02 00 E8 ? ? ? ? 85 C0 79 06");
-		injector::WriteMemory<uint8_t>(location + 0x12, 0xEB, true);
-		*/
-	}
-	//safeJMP(hook::get_pattern(V("48 83 EC 28 33 D2 B9 70 00 02 00 E8 ? ? ? ? 85 C0 79 06")), ReturnTrue);
+		// I don't know what this is for sorry
+		injector::MakeNOP(imageBasedxplus + 0x9F2BB3, 2);
 
-	if (isTerminal)
-	{
-		// Patch some func to 1
-		// 
-		// FOUND ON 21, 10, 1
-		// NOT FOUND:
-		//safeJMP(imageBase + 0x7BE440, ReturnTrue);
-		//safeJMP(hook::get_pattern("0F B6 41 05 2C 30 3C 09 77 04 0F BE C0 C3 83 C8 FF C3"), ReturnTrue);
-		//safeJMP(imageBase + 0x89D420, ReturnTrue);
-
-		// Patch some func to 1
-		// 40 53 48 83 EC 20 48 83 39 00 48 8B D9 75 28 48 8D ?? ?? ?? ?? 00 48 8D ?? ?? ?? ?? 00 41 B8 ?? ?? 00 00 FF 15 ?? ?? ?? ?? 4C 8B 1B 41 0F B6 43 78
-		// FOUND ON 21, 10, 1
-		//safeJMP(imageBase + 0x7CF8D0, ReturnTrue); 
-		//safeJMP(hook::get_pattern("40 53 48 83 EC 20 48 83 39 00 48 8B D9 75 11 48 8B 0D C2"), ReturnTrue);
-		//safeJMP(imageBase + 0x8B5190, ReturnTrue); 
-	}
-	else
-	{
-		// Disregard terminal scanner stuff.
-		// 48 8B 18 48 3B D8 0F 84 88 00 00 00 39 7B 1C 74 60 80 7B 31 00 75 4F 48 8B 43 10 80 78 31 00
-		// FOUND ON 21, 10, 1
-		//injector::MakeNOP(imageBase + 0x91E1AE, 6);
-		//injector::MakeNOP(imageBase + 0x91E1B7, 2);
-		//injector::MakeNOP(imageBase + 0x91E1BD, 2);
-		
-		{
-		
-			/*
-			auto location = hook::get_pattern<char>("48 8B 18 48 3B D8 0F 84 8B 00 00 00 0F 1F 80 00 00 00 00 39 73 1C 74 5C 80 7B 31 00");
-			//injector::MakeNOP(location + 6, 6); // 6
-			injector::MakeNOP(location + 0xF, 2); // 0xF
-			//injector::MakeNOP(location + 0x15, 2); // 0x15
-			*/
-			injector::MakeNOP(imageBasedxplus + 0x9F2BB3, 2);
-		}
-		
-
-		// spam thread
+		// If terminal emulator is enabled
 		if (ToBool(config["General"]["TerminalEmulator"]))
 		{
-			CreateThread(0, 0, SpamMulticast, 0, 0, 0);			
+			// Start the multicast spam thread
+			CreateThread(0, 0, SpamMulticast, 0, 0, 0);
 		}
 	}
 
@@ -1284,93 +1125,41 @@ static InitFunction Wmmt5Func([]()
 		}
 	}
 
-	if (ToBool(config["General"]["SkipMovies"]))
-	{
-		// Skip movies fuck you wmmt5
-		//safeJMP(imageBase + 0x806020, ReturnTrue);
-	}
-
+	// Get the custom name specified in the  config file
 	std::string value = config["General"]["CustomName"];
+
+	// If a custom name is set
 	if (!value.empty())
 	{
-		
+		// Zero out the custom name variable
 		memset(customNamedxp, 0, 256);
+
+		// Copy the custom name to the custom name block
 		strcpy(customNamedxp, value.c_str());
+
+		// Create the spam custom name thread
 		CreateThread(0, 0, SpamcustomNamedxp, 0, 0, 0);
-		
 	}
 
 	// Save story stuff (only 05)
 	{
-
-		// skip erasing of temp card data
-		//injector::WriteMemory<uint8_t>(imageBase + 0xA35CA3, 0xEB, true);
-		/*
-		// Skip erasing of temp card
-		safeJMP(imageBase + 0x54DCE1, LoadGameData);
-		safeJMP(imageBase + 0x5612F0, ReturnTrue);
-		safeJMP(imageBase + 0x5753C0, ReturnTrue);
-		safeJMP(imageBase + 0x57DF10, ReturnTrue);
-
-		safeJMP(imageBase + 0x92DB20, ReturnTrue);
-		safeJMP(imageBase + 0x5628C0, ReturnTrue);
-		safeJMP(imageBase + 0x579090, ReturnTrue);
-
-		// Skip more
-		safeJMP(imageBase + 0x54B0F0, ReturnTrue);
-		safeJMP(imageBase + 0x909DB0, ReturnTrue);
-		safeJMP(imageBase + 0x59FD90, ReturnTrue);
-		safeJMP(imageBase + 0x5A0030, ReturnTrue);
-		safeJMP(imageBase + 0x915370, ReturnTrue);
-		safeJMP(imageBase + 0x5507A0, ReturnTrue);
-		safeJMP(imageBase + 0x561290, ReturnTrue);
-
-		safeJMP(imageBase + 0x5A0AE8, LoadWmmt5CarData);
-
-		// crash fix
-		//safeJMP(imageBase + 0xAD6F28, WmmtOperatorDelete);
-		//safeJMP(imageBase + 0xAD6F4C, WmmtMemset);
-
-		// Save progress trigger
-		injector::WriteMemory<WORD>(imageBase + 0x556CE3, 0xB848, true);
-		injector::WriteMemory<uintptr_t>(imageBase + 0x556CE3 + 2, (uintptr_t)SaveOk, true);
-		injector::WriteMemory<DWORD>(imageBase + 0x556CED, 0x9090D0FF, true);
-
-		// Try save later!
-		injector::MakeNOP(imageBase + 0x308546, 0x12);
-		injector::WriteMemory<WORD>(imageBase + 0x308546, 0xB848, true);
-		injector::WriteMemory<uintptr_t>(imageBase + 0x308546 + 2, (uintptr_t)SaveGameData, true);
-		injector::WriteMemory<DWORD>(imageBase + 0x308550, 0x3348D0FF, true);
-		injector::WriteMemory<WORD>(imageBase + 0x308550 + 4, 0x90C0, true);
-
-		CreateThread(0, 0, Wmmt5FfbCollector, 0, 0, 0);
-		*/
-
 		// Enable all print
 		injector::MakeNOP(imageBasedxplus + 0x898BD3, 6);
 
-		//load car trigger
+		// Load car trigger
 		safeJMP(imageBasedxplus + 0x72AB90, loadCar);
 
-		//save car trigger
-		//injector::WriteMemory<uintptr_t>(imageBase + 0x376F80 + 2, (uintptr_t)SaveGameData, true);
-		//safeJMP(imageBase + 0x376F76, SaveGameData);
-
-		
+		// Save car trigger
 		injector::MakeNOP(imageBasedxplus + 0x376F76, 0x12);
 		injector::WriteMemory<WORD>(imageBasedxplus + 0x376F76, 0xB848, true);
 		injector::WriteMemory<uintptr_t>(imageBasedxplus + 0x376F76 + 2, (uintptr_t)SaveGameData, true);
 		injector::WriteMemory<DWORD>(imageBasedxplus + 0x376F80, 0x3348D0FF, true);
 		injector::WriteMemory<WORD>(imageBasedxplus + 0x376F80 + 4, 0x90C0, true);
 
-		//prevents startup saving
-		//injector::MakeNOP(imageBase + 0x6B908C, 0x0D);
-		//safeJMP(imageBase + 0x6B908C, SaveOk);
+		// Prevents startup saving
 		injector::WriteMemory<WORD>(imageBasedxplus + 0x6B909A, 0xB848, true);
 		injector::WriteMemory<uintptr_t>(imageBasedxplus + 0x6B909A + 2, (uintptr_t)SaveOk, true);
 		injector::WriteMemory<DWORD>(imageBasedxplus + 0x6B90A4, 0x9090D0FF, true);
-
-
 	}
 
 	MH_EnableHook(MH_ALL_HOOKS);

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
@@ -695,8 +695,11 @@ static void LoadWmmt5carDataDxp()
 			return;
 		}
 	}
+
+	// If the force full tune switch is set
 	if (ToBool(config["Tune"]["Force Full Tune"]))
 	{
+		// Create the force full tune thread
 		CreateThread(0, 0, forceFullTune, 0, 0, 0);
 	}
 

--- a/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
+++ b/OpenParrot/src/Functions/Games/ES3X/WMMT5DXPlus.cpp
@@ -419,10 +419,17 @@ bool WINAPI Hook_SetSystemTime(SYSTEMTIME* in)
 	return TRUE;
 }
 
-static DWORD WINAPI forceFT(void* pArguments)
+// forceFullTune(pArguments: void*): DWORD WINAPI
+// Function which runs in a secondary thread if the forceFullTune
+// option is selected in the menu. If the player's car is not fully
+// tuned, it is forcibly set to max tune. If the player's car is already
+// fully tuned, it is left alone. 
+static DWORD WINAPI forceFullTune(void* pArguments)
 {
+	// Loops while the program is running
 	while (true) {
 
+		// Only runs every 16th frame
 		Sleep(16);
 
 		// Get the memory addresses for the car base save, power and handling values
@@ -806,7 +813,7 @@ static void LoadWmmt5CarData()
 	}
 	if (ToBool(config["Tune"]["Force Full Tune"]))
 	{
-		CreateThread(0, 0, forceFT, 0, 0, 0);
+		CreateThread(0, 0, forceFullTune, 0, 0, 0);
 	}
 
 	memset(carFileNamedxp, 0, 0xFF);

--- a/commit-and-copy.ps1
+++ b/commit-and-copy.ps1
@@ -12,7 +12,7 @@ Try
     $OpenParrot32Files = @(
         "iDmacDrv32.dll", 
         "OpenParrot.dll",
-        "OpenParrotKonamiLoader",
+        "OpenParrotKonamiLoader.exe",
         "OpenParrotLoader.exe"
     );
 

--- a/commit-and-copy.ps1
+++ b/commit-and-copy.ps1
@@ -1,0 +1,77 @@
+Try
+{
+    Write-Host -ForeGroundColor Blue "Processing commit ...";
+
+    # TeknoParrot install path
+    $TeknoPath = "D:\Games\TeknoParrot";
+
+    # Path to OpenParrot x86 Files
+    $OpenParrot32 = Join-Path -Path $TeknoPath -ChildPath "OpenParrotWin32";
+
+    # 32-bit OpenParrot files
+    $OpenParrot32Files = @(
+        "iDmacDrv32.dll", 
+        "OpenParrot.dll",
+        "OpenParrotKonamiLoader",
+        "OpenParrotLoader.exe"
+    );
+
+    # Path to OpenParrot x64 files
+    $OpenParrot64 = Join-Path -Path $TeknoPath -ChildPath "OpenParrotx64";
+
+    # 64-Bit OpenParrot files
+    $OpenParrot64Files = @(
+        "iDmacDrv64.dll",
+        "OpenParrot64.dll",
+        "OpenParrotLoader64.exe"
+    );
+
+    # Get the user's current location
+    $Location = Get-Location;
+
+    # Set the location to the script path
+    Set-Location $PSScriptRoot;
+
+    # Get the build output path
+    $BuildPath = Join-Path -Path $PSScriptRoot -ChildPath "build\bin\release\output";
+
+    # Add all files to the repo
+    git add .;
+
+    # Ensure the test branch is checked out
+    git checkout test
+
+    # Commit the changes to the repo
+    git commit -m "[$(Get-Date)] pre-test commit";
+
+    # Push the changes to the test branch
+    git push origin test
+
+    # Master branch will need to be merged manually once test is ensured working
+    
+    # Copy the win32 files from the build path to the tekno path
+    ForEach($File in $OpenParrot32Files)
+    {
+        # Get the path for the file we are copying
+        $Path = Join-Path -Path $BuildPath -ChildPath $File;
+
+        # Copy the file to the win32 folder, overwriting existing
+        Copy-Item -Path $Path -Destination $OpenParrot32 -Force;
+    }
+
+    # Copy the win64 files from the build path to the tekno path
+    ForEach($File in $OpenParrot64Files)
+    {
+        # Get the path for the file we are copying
+        $Path = Join-Path -Path $BuildPath -ChildPath $File;
+
+        # Copy the file to the win64 folder, overwriting existing
+        Copy-Item -Path $Path -Destination $OpenParrot64 -Force;
+    }
+
+    Write-Host -ForeGroundColor Green "Commit processed and copied successfully.";
+}
+Catch # Failed to commit / copy files
+{
+    Write-Host -ForeGroundColor Red "Failed to process commit! Reason: $($_.Exception.Message)";
+}


### PR DESCRIPTION
Force Full Tune fully working for MT5. Just need to manually create "Force Full Tune" button in MT5 XML file. 

Force Full Tune function has been configured to not overwrite the speed/handling settings of cars that are already full tuned. 

MT5 car loading has been modified to display the specific values and where they are imported to, (i.e. Power, Handling, Aero, etc.). Work on story saving for MT5DX+ has been started, however it is not currently working.

 Data is dumped to openparrot.sav, however it does not read back correctly and it is not known if the data currently dumped is on the correct site.