### PR TITLE
Fix Broken Links

### DIFF
--- a/OpenParrot/src/Utility/Hooking.Patterns.cpp
+++ b/OpenParrot/src/Utility/Hooking.Patterns.cpp
@@ -1,5 +1,5 @@
 /*
- * This file is part of the CitizenFX project - http://citizen.re/
+ * This file is part of the CitizenFX project - https://github.com/citizenfx
  *
  * See LICENSE and MENTIONS in the root of the source tree for information
  * regarding licensing.

--- a/OpenParrot/src/Utility/Hooking.Patterns.h
+++ b/OpenParrot/src/Utility/Hooking.Patterns.h
@@ -1,5 +1,5 @@
 /*
-* This file is part of the CitizenFX project - http://citizen.re/
+* This file is part of the CitizenFX project - https://github.com/citizenfx
 *
 * See LICENSE and MENTIONS in the root of the source tree for information
 * regarding licensing.


### PR DESCRIPTION
### Summery

The ```http://citizen.re/``` website does not exist anymore. So I have replaced it with a link to their GitHub.

### Support my work

This link was found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐