### PR TITLE
FNF SuperCars Control tidy

### DIFF
--- a/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
+++ b/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
@@ -5,7 +5,6 @@
 #include <Xinput.h>
 #include <math.h>
 #include <dinput.h>
-#include "MinHook.h"
 #pragma comment(lib, "Ws2_32.lib")
 
 #define clamp( x, xmin, xmax ) min( xmax, max( x, xmin ) )

--- a/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
+++ b/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
@@ -5,7 +5,7 @@
 #include <Xinput.h>
 #include <math.h>
 #include <dinput.h>
-
+#include "MinHook.h"
 #pragma comment(lib, "Ws2_32.lib")
 
 #define clamp( x, xmin, xmax ) min( xmax, max( x, xmin ) )
@@ -17,24 +17,21 @@ int vertical2 = 0;
 HWND hWndRT2 = 0;
 HCURSOR cursorhndle2;
 
-static bool previousLeft = false;
-static bool previousRight = false;
-static bool previousUp = false;
-static bool previousDown = false;
-static bool button1pressed = false;
-static bool button2pressed = false;
-static bool button3pressed = false;
-static bool button4pressed = false;
-static bool musicpressed = false;
-
 // controls
 extern int* ffbOffset;
 extern int* ffbOffset2;
 extern int* ffbOffset3;
 extern int* ffbOffset4;
+extern int* ffbOffset5;
 // hooks ori
 BOOL(__stdcall* original_SetWindowPos2)(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, UINT uFlags);
 BOOL(__stdcall* original_CreateWindowExA2)(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int X, int Y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam);
+
+static int(__cdecl* SetControlOrig)(u_int param_1, u_int param_2);
+static int __cdecl SetControl(u_int param_1, u_int param_2)
+{
+	return SetControlOrig(param_1, param_2);
+}
 
 DWORD WINAPI InputRT2(LPVOID lpParam)
 {
@@ -42,169 +39,365 @@ DWORD WINAPI InputRT2(LPVOID lpParam)
 	INT_PTR keyboardBuffer = (0x437F6F8 + BaseAddress2);
 	INT_PTR keyboardBuffer2 = (0x437FC08 + BaseAddress2);
 
+	bool startPressed = false;
+	bool button1Pressed = false;
+	bool button2Pressed = false;
+	bool button3Pressed = false;
+	bool buttonMusicPressed = false;
+	bool buttonCoin1Pressed = false;
+	bool buttonCoin2Pressed = false;
+	bool buttonBillPressed = false;
+	bool buttonTestPressed = false;
+	bool buttonVolumeUpPressed = false;
+	bool buttonVolumeDownPressed = false;
+	bool buttonCreditPressed = false;
+
+	bool buttonGear1Pressed = false;
+	bool buttonGear2Pressed = false;
+	bool buttonGear3Pressed = false;
+	bool buttonGear4Pressed = false;
+	bool buttonGear5Pressed = false;
+	bool buttonGear6Pressed = false;
+
+	bool buttonBrakePressed = false;
+
+	bool numpad0Pressed = false;
+	bool numpad1Pressed = false;
+	bool numpad2Pressed = false;
+	bool numpad3Pressed = false;
+	bool numpad4Pressed = false;
+	bool numpad5Pressed = false;
+	bool numpad6Pressed = false;
+	bool numpad7Pressed = false;
+	bool numpad8Pressed = false;
+	bool numpad9Pressed = false;
+	bool numpadStarPressed = false;
+	bool numpadSlashPressed = false;
+
+
 	while (true)
 	{
-		// buttons see bitwise values in TPui//RawThrills.cs
-		// START ( = NITRO too)
+
+		if (GetAsyncKeyState(VK_NUMPAD0) & 1)
+		{
+			SetControlOrig(0x10080, 0x1);
+			numpad0Pressed = true;
+		}
+		else if (numpad0Pressed) {
+			SetControlOrig(0x10080, 0x0);
+			numpad0Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD1) & 1)
+		{
+			SetControlOrig(0x10081, 0x1);
+			numpad1Pressed = true;
+		}
+		else if (numpad1Pressed) {
+			SetControlOrig(0x10081, 0x0);
+			numpad1Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD2) & 1)
+		{
+			SetControlOrig(0x10082, 0x1);
+			numpad2Pressed = true;
+		}
+		else if (numpad2Pressed) {
+			SetControlOrig(0x10082, 0x0);
+			numpad2Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD3) & 1)
+		{
+			SetControlOrig(0x10083, 0x1);
+			numpad3Pressed = true;
+		}
+		else if (numpad3Pressed) {
+			SetControlOrig(0x10083, 0x0);
+			numpad3Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD4) & 1)
+		{
+			SetControlOrig(0x10084, 0x1);
+			numpad4Pressed = true;
+		}
+		else if (numpad4Pressed) {
+			SetControlOrig(0x10084, 0x0);
+			numpad4Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD5) & 1)
+		{
+			SetControlOrig(0x10085, 0x1);
+			numpad5Pressed = true;
+		}
+		else if (numpad5Pressed) {
+			SetControlOrig(0x10085, 0x0);
+			numpad5Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD6) & 1)
+		{
+			SetControlOrig(0x10086, 0x1);
+			numpad6Pressed = true;
+		}
+		else if (numpad6Pressed) {
+			SetControlOrig(0x10086, 0x0);
+			numpad6Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD7) & 1)
+		{
+			SetControlOrig(0x10087, 0x1);
+			numpad7Pressed = true;
+		}
+		else if (numpad7Pressed) {
+			SetControlOrig(0x10087, 0x0);
+			numpad7Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD8) & 1)
+		{
+			SetControlOrig(0x10088, 0x1);
+			numpad8Pressed = true;
+		}
+		else if (numpad8Pressed) {
+			SetControlOrig(0x10088, 0x0);
+			numpad8Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_NUMPAD9) & 1)
+		{
+			SetControlOrig(0x10089, 0x1);
+			numpad9Pressed = true;
+		}
+		else if (numpad9Pressed) {
+			SetControlOrig(0x10089, 0x0);
+			numpad9Pressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_MULTIPLY) & 1)
+		{
+			SetControlOrig(0x1008A, 0x1);
+			numpadStarPressed = true;
+		}
+		else if (numpadStarPressed) {
+			SetControlOrig(0x1008A, 0x0);
+			numpadStarPressed = false;
+		}
+
+		if (GetAsyncKeyState(VK_DIVIDE) & 1)
+		{
+			SetControlOrig(0x1008B, 0x1);
+			numpadSlashPressed = true;
+		}
+		else if (numpadSlashPressed) {
+			SetControlOrig(0x1008B, 0x0);
+			numpadSlashPressed = false;
+		}
+
+		//START
 		if (*ffbOffset & 0x08)
 		{
-			injector::WriteMemory<BYTE>((keyboardBuffer2 + 4 * 0x00), 2, true);
-			injector::WriteMemory<BYTE>((keyboardBuffer + DIK_NUMPADENTER), 2, true);
+			if (!startPressed)
+			{
+				SetControlOrig(0x10000, 0x1);
+				startPressed = true;
+			}
+		}
+		else if (startPressed) {
+			SetControlOrig(0x10000, 0x0);
+			startPressed = false;
+		}
 
-		}
-		// TEST
-		if (*ffbOffset & 0x01)
-		{
-			injector::WriteMemory<BYTE>(keyboardBuffer2 + 0x0B * sizeof(U32), 2, true);
-		}
-		// NITRO ( = START too)
-		if (*ffbOffset & 0x100)
-		{
-			if (button1pressed == false)
-			{
-				injector::WriteMemory<BYTE>((keyboardBuffer2 + 4 * 0x00), 2, true);
-				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_NUMPADENTER), 2, true);
-				button1pressed = true;
-			}
-		}
-		else
-		{
-			if (button1pressed == true)
-			{
-				button1pressed = false;
-			}
-		}
-		// SHIFT DOWN
-		if (*ffbOffset & 0x2000)
-		{
-			if (previousDown == false)
-			{
-				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_DOWN), 2, true);
-				previousDown = true;
-			}
-		}
-		else
-		{
-			if (previousDown == true)
-			{
-				previousDown = false;
-			}
-		}
-		// SHIFT UP
-		if (*ffbOffset & 0x1000)
-		{
-			if (previousUp == false)
-			{
-				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_UP), 2, true);
-				previousUp = true;
-			}
-		}
-		else
-		{
-			if (previousUp == true)
-			{
-				previousUp = false;
-			}
-		}
-		// BUTTON 1/ VIEW 1
+		//BUTTON 1
 		if (*ffbOffset & 0x200)
 		{
-			if (button2pressed == false)
+			if (!button1Pressed)
 			{
-				injector::WriteMemory<BYTE>(keyboardBuffer + DIK_A, 2, true);
-				injector::WriteMemory<BYTE>(keyboardBuffer2 + 0x01 * sizeof(U32), 2, true);
-				button2pressed = true;
+				SetControlOrig(0x10001, 0x1);
+				button1Pressed = true;
 			}
 		}
-		else
-		{
-			if (button2pressed == true)
-			{
-				button2pressed = false;
-			}
+		else if (button1Pressed) {
+			SetControlOrig(0x10001, 0x0);
+			button1Pressed = false;
 		}
-		// BUTTON 2/ VIEW 2
+
+		//BUTTON 2
 		if (*ffbOffset & 0x400)
 		{
-			if (button3pressed == false)
+			if (!button2Pressed)
 			{
-				injector::WriteMemory<BYTE>(keyboardBuffer + DIK_B, 2, true);
-				injector::WriteMemory<BYTE>(keyboardBuffer2 + 0x02 * sizeof(U32), 2, true);
-				button3pressed = true;
+				SetControlOrig(0x10002, 0x1);
+				button2Pressed = true;
 			}
 		}
-		else
-		{
-			if (button3pressed == true)
-			{
-				button3pressed = false;
-			}
+		else if (button2Pressed) {
+			SetControlOrig(0x10002, 0x0);
+			button2Pressed = false;
 		}
-		// BUTTON 3/ VIEW 3
+
+		//BUTTON 3
 		if (*ffbOffset & 0x800)
 		{
-			if (button4pressed == false)
+			if (!button3Pressed)
 			{
-				injector::WriteMemory<BYTE>(keyboardBuffer + DIK_E, 2, true);
-				injector::WriteMemory<BYTE>(keyboardBuffer2 + 0x03 * sizeof(U32), 2, true);
-				button4pressed = true;
+				SetControlOrig(0x10003, 0x1);
+				button3Pressed = true;
 			}
 		}
-		else
-		{
-			if (button4pressed == true)
-			{
-				button4pressed = false;
-			}
+		else if (button3Pressed) {
+			SetControlOrig(0x10003, 0x0);
+			button3Pressed = false;
 		}
-		// BUTTON MUSIC
+
+		//BUTTON MUSIC
 		if (*ffbOffset & 0x10)
 		{
-			if (musicpressed == false)
+			if (!buttonMusicPressed)
 			{
-				injector::WriteMemory<BYTE>(keyboardBuffer2 + 0x04 * sizeof(U32), 2, true);
-				musicpressed = true;
+				SetControlOrig(0x10004, 0x1);
+				buttonMusicPressed = true;
 			}
 		}
-		else
+		else if (buttonMusicPressed) {
+			SetControlOrig(0x10004, 0x0);
+			buttonMusicPressed = false;
+		}
+
+		//BUTTON TEST
+		if (*ffbOffset & 0x01)
 		{
-			if (musicpressed == true)
+			if (!buttonTestPressed)
 			{
-				musicpressed = false;
+				SetControlOrig(0x1000b, 0x1);
+				buttonTestPressed = true;
 			}
 		}
-		// MENU LEFT
+		else if (buttonTestPressed) {
+			SetControlOrig(0x1000b, 0x0);
+			buttonTestPressed = false;
+		}
+
+		//BUTTON COIN 1
+		if (*ffbOffset & 0x0004)
+		{
+			if (!buttonCoin1Pressed)
+			{
+				SetControlOrig(0x10009, 0x1);
+				buttonCoin1Pressed = true;
+			}
+		}
+		else if (buttonCoin1Pressed) {
+			SetControlOrig(0x10009, 0x0);
+			buttonCoin1Pressed = false;
+		}
+
+
+		//BUTTON VOLUME UP
 		if (*ffbOffset & 0x4000)
 		{
-			if (previousLeft == false)
+			if (!buttonVolumeUpPressed)
 			{
-				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_LEFT), 2, true);
-				previousLeft = true;
+				SetControlOrig(0x1000e, 0x1);
+				buttonVolumeUpPressed = true;
 			}
 		}
-		else
-		{
-			if (previousLeft == true)
-			{
-				previousLeft = false;
-			}
+		else if (buttonVolumeUpPressed) {
+			SetControlOrig(0x1000e, 0x0);
+			buttonVolumeUpPressed = false;
 		}
-		// MENU RIGHT
+
+		//BUTTON VOLUME DOWN
 		if (*ffbOffset & 0x8000)
 		{
-			if (previousRight == false)
+			if (!buttonVolumeDownPressed)
 			{
-				injector::WriteMemory<BYTE>((keyboardBuffer + DIK_RIGHT), 2, true);
-				previousRight = true;
+				SetControlOrig(0x1000f, 0x1);
+				buttonVolumeDownPressed = true;
 			}
 		}
-		else
+		else if (buttonVolumeDownPressed) {
+			SetControlOrig(0x1000f, 0x0);
+			buttonVolumeDownPressed = false;
+		}
+
+
+
+		//GEAR 1 
+		if (*ffbOffset5 & 0x1)
 		{
-			if (previousRight == true)
+			if (!buttonGear1Pressed)
 			{
-				previousRight = false;
+				SetControlOrig(0x10005, 0x1);
+				SetControlOrig(0x10006, 0x0);
+				SetControlOrig(0x10007, 0x0);
+				SetControlOrig(0x10008, 0x0);
+				buttonGear1Pressed = true;
 			}
 		}
+		else if (buttonGear1Pressed) {
+			SetControlOrig(0x10005, 0x0);
+			buttonGear1Pressed = false;
+		}
+
+		//GEAR 2
+		if (*ffbOffset5 & 0x2)
+		{
+			if (!buttonGear2Pressed)
+			{
+				SetControlOrig(0x10006, 0x1);
+				SetControlOrig(0x10005, 0x0);
+				SetControlOrig(0x10007, 0x0);
+				SetControlOrig(0x10008, 0x0);
+				buttonGear2Pressed = true;
+			}
+		}
+		else if (buttonGear2Pressed) {
+			SetControlOrig(0x10006, 0x0);
+			buttonGear2Pressed = false;
+		}
+
+		//GEAR 3
+		if (*ffbOffset5 & 0x4)
+		{
+			if (!buttonGear3Pressed)
+			{
+				SetControlOrig(0x10007, 0x1);
+				SetControlOrig(0x10005, 0x0);
+				SetControlOrig(0x10006, 0x0);
+				SetControlOrig(0x10008, 0x0);
+				buttonGear3Pressed = true;
+			}
+		}
+		else if (buttonGear3Pressed) {
+			SetControlOrig(0x10007, 0x0);
+			buttonGear3Pressed = false;
+		}
+
+		//GEAR 4 TODO
+		if (*ffbOffset5 & 0x8)
+		{
+			if (!buttonGear4Pressed)
+			{
+				SetControlOrig(0x10008, 0x1);
+				SetControlOrig(0x10005, 0x0);
+				SetControlOrig(0x10006, 0x0);
+				SetControlOrig(0x10007, 0x0);
+				buttonGear4Pressed = true;
+			}
+		}
+		else if (buttonGear4Pressed) {
+			SetControlOrig(0x10008, 0x0);
+			buttonGear4Pressed = false;
+		}
+
+
+		// Need to do this in a mo
+
 		// WHEEL
 		int iWheel0 = (((float)*ffbOffset2) - 128);
 		float wheel = (iWheel0 * 0.0078125f);
@@ -317,6 +510,14 @@ DWORD WINAPI SetWindowPosRT2(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int 
 	return 1;
 }
 
+
+static int(__cdecl* SetUSBIOOnOrig)();
+static int __cdecl SetUSBIOOn()
+{
+	return 1;
+}
+
+
 static InitFunction FNFSCFunc([]()
 	{
 		GetDesktopResolution(horizontal2, vertical2);
@@ -331,12 +532,21 @@ static InitFunction FNFSCFunc([]()
 		// REMOVE ESC BOX
 		injector::MakeNOP((0x464A58), 5, true);
 
+		//TURN OFF hack for keyboard + dinput, we'll do it ourselves above.
+		injector::MakeNOP((0x04741db), 5, true);
+
 		CreateThread(NULL, 0, InputRT2, NULL, 0, NULL);
 
 		MH_Initialize();
 		MH_CreateHookApi(L"user32.dll", "CreateWindowExA", &CreateWindowExART2, (void**)&original_CreateWindowExA2);
 		MH_CreateHookApi(L"user32.dll", "SetWindowPos", &SetWindowPosRT2, (void**)&original_SetWindowPos2);
+		MH_CreateHook((void*)0x04a9510, SetControl, (void**)&SetControlOrig);
+		MH_CreateHook((void*)0x0401ab0, SetUSBIOOn, (void**)&SetUSBIOOnOrig);
+
+
 		MH_EnableHook(MH_ALL_HOOKS);
+
+
 
 		if (ToBool(config["General"]["Windowed"]))
 		{
@@ -355,7 +565,7 @@ static InitFunction FNFSCFunc([]()
 
 		// use relative paths instead of absolute paths 
 		safeJMP(0x4a7ee0, genericRetZero, true);
-		
+
 		// Changing the res breaks any sort of 2D UI T_T
 		//injector::WriteMemory<DWORD>(0x730f24, 1920, true);
 		//injector::WriteMemory<DWORD>(0x730f28, 1080, true);


### PR DESCRIPTION
- Re done controls to use actual ingame hooks, so all controls now work as original machine.
- Added numeric keypad functionality
- Removed hard coded hacked in Dinput + keyboard controls from original exe now un-needed
- Re-enabled IO calls, resulting in proper wheel emulation and more.
- Enables OutputBlaster to function also!
- Requires new FNFSC.xml in openparrot (I've pushed PR for this also)