### PR TITLE
Patches to fix tampered executables for BG4 Tuned JPN

### DIFF
--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -721,11 +721,6 @@ static InitFunction initFunction([]()
 		}
 		case X2Type::BG4_Eng:
 		{
-			// TODO: DOCUMENT PATCHES
-			//injector::MakeNOP(0x4CBCB8, 10);
-			//injector::WriteMemory<uint8_t>(0x4CBCB8, 0xB8, true);
-			//injector::WriteMemory<uint32_t>(0x4CBCB9, 1, true);
-
 			// redirect E:\data to .\data
 			injector::WriteMemoryRaw(0x0073139C, "./data/", 8, true);
 			injector::WriteMemoryRaw(0x00758978, ".\\data", 7, true);

--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -666,6 +666,7 @@ static InitFunction initFunction([]()
 			injector::WriteMemoryRaw(imageBase + 0x2EF484, "\x6A\x60\x68\x28\xac\x7c\x00", 7, true);				// We replace the dll injection routine with the initial stack pushes to correctly set up the stack for the subroutine call following the patched instructions...
 			safeJMP(imageBase + 0x2ef484 + 7, imageBase + 0x2837e7);												// THEN insert a jump back to the original entry point +7 bytes offset (to skip the patched in JMP) which calls __SEH_prolog with the stack pushes from earlier
 																													// Has to be done this way as TP does not patch quickly enough to prevent the initial entry point JMP, it will branch regardless (Thanks Pocky for workaround)
+																													// This shouldnt cause an issue with clean exes as they wont jump here in the first place
 
 			injector::WriteMemoryRaw(imageBase + 0xCBCB8, "\x8B\x84\x81\x94\x00\x00\x00\x8B\x40\x04", 10, true);	// Revert weird transmission patch?
 																													// Causes Seq/6MT to be disabled in pro mode

--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -660,22 +660,12 @@ static InitFunction initFunction([]()
 			// Rename window name
 			injector::WriteMemoryRaw(imageBase + 0x36B790, "\x4F\x70\x65\x6E\x50\x61\x72\x72\x6F\x74\x20\x2D\x20\x42\x61\x74\x74\x6C\x65\x20\x47\x65\x61\x72\x20\x34\x20\x54\x75\x6E\x65\x64", 37, true);
 
-			// Below will un-patch dirty executables
-			char dllName[16];
-			// Firstly we check where the dll injection routine is usually stored
-			// this is the modified entry point used for dll injection by these patched executables
-			injector::ReadMemoryRaw(imageBase + 0x2EF470, &dllName, sizeof(dllName), true);
-			if ((strncmp(dllName + 1, "ttx_monitor.dll", 15) | 	// Check what dll is being injected (if any)
-				strncmp(dllName, "JVSEmuBG", 8)) == 0)
-			{
-				// We know this is likely to be a dirty executable if the above strncmp succeeds
-				injector::MemoryFill(imageBase + 0x2EF470, 0, 48, true);												// Remove dll injection routine
-				injector::WriteMemoryRaw(imageBase + 0x2837E0, "\x6A\x60\x68\x28\xAC\x7C\x00", 7, true);				// Fix injected jmp instruction at the program's entry point, 
-																														// which jumps to the dll injection routine
-				injector::WriteMemoryRaw(imageBase + 0xCBCB8, "\x8B\x84\x81\x94\x00\x00\x00\x8B\x40\x04", 10, true);	// Revert weird transmission patch?
-																														// Causes Seq/6MT to be disabled in pro mode
-
-			}
+			// below will un-patch dirty executables
+			injector::MemoryFill(imageBase + 0x2EF470, 0, 48, true);												// Remove dll injection routine
+			injector::WriteMemoryRaw(imageBase + 0x2837E0, "\x6A\x60\x68\x28\xAC\x7C\x00", 7, true);				// Fix injected jmp instruction at the program's entry point, 
+																													// which jumps to the dll injection routine
+			injector::WriteMemoryRaw(imageBase + 0xCBCB8, "\x8B\x84\x81\x94\x00\x00\x00\x8B\x40\x04", 10, true);	// Revert weird transmission patch?
+																													// Causes Seq/6MT to be disabled in pro mode
 			
 			if (ToBool(config["General"]["IntroFix"]))
 			{

--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -660,6 +660,23 @@ static InitFunction initFunction([]()
 			// Rename window name
 			injector::WriteMemoryRaw(imageBase + 0x36B790, "\x4F\x70\x65\x6E\x50\x61\x72\x72\x6F\x74\x20\x2D\x20\x42\x61\x74\x74\x6C\x65\x20\x47\x65\x61\x72\x20\x34\x20\x54\x75\x6E\x65\x64", 37, true);
 
+			// Below will un-patch dirty executables
+			char dllName[16];
+			// Firstly we check where the dll injection routine is usually stored
+			// this is the modified entry point used for dll injection by these patched executables
+			injector::ReadMemoryRaw(imageBase + 0x2EF470, &dllName, sizeof(dllName), true);
+			if ((strncmp(dllName + 1, "ttx_monitor.dll", 15) | 	// Check what dll is being injected (if any)
+				strncmp(dllName, "JVSEmuBG", 8)) == 0)
+			{
+				// We know this is likely to be a dirty executable if the above strncmp succeeds
+				injector::MemoryFill(imageBase + 0x2EF470, 0, 48, true);												// Remove dll injection routine
+				injector::WriteMemoryRaw(imageBase + 0x2837E0, "\x6A\x60\x68\x28\xAC\x7C\x00", 7, true);				// Fix injected jmp instruction at the program's entry point, 
+																														// which jumps to the dll injection routine
+				injector::WriteMemoryRaw(imageBase + 0xCBCB8, "\x8B\x84\x81\x94\x00\x00\x00\x8B\x40\x04", 10, true);	// Revert weird transmission patch?
+																														// Causes Seq/6MT to be disabled in pro mode
+
+			}
+			
 			if (ToBool(config["General"]["IntroFix"]))
 			{
 				// thanks for Ducon2016 for the patch!

--- a/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
+++ b/OpenParrot/src/Functions/Games/TypeX2/TypeX2Generic.cpp
@@ -660,12 +660,16 @@ static InitFunction initFunction([]()
 			// Rename window name
 			injector::WriteMemoryRaw(imageBase + 0x36B790, "\x4F\x70\x65\x6E\x50\x61\x72\x72\x6F\x74\x20\x2D\x20\x42\x61\x74\x74\x6C\x65\x20\x47\x65\x61\x72\x20\x34\x20\x54\x75\x6E\x65\x64", 37, true);
 
-			// below will un-patch dirty executables
+			// Below will (mostly) un-patch dirty executables
 			injector::MemoryFill(imageBase + 0x2EF470, 0, 48, true);												// Remove dll injection routine
-			injector::WriteMemoryRaw(imageBase + 0x2837E0, "\x6A\x60\x68\x28\xAC\x7C\x00", 7, true);				// Fix injected jmp instruction at the program's entry point, 
-																													// which jumps to the dll injection routine
+
+			injector::WriteMemoryRaw(imageBase + 0x2EF484, "\x6A\x60\x68\x28\xac\x7c\x00", 7, true);				// We replace the dll injection routine with the initial stack pushes to correctly set up the stack for the subroutine call following the patched instructions...
+			safeJMP(imageBase + 0x2ef484 + 7, imageBase + 0x2837e7);												// THEN insert a jump back to the original entry point +7 bytes offset (to skip the patched in JMP) which calls __SEH_prolog with the stack pushes from earlier
+																													// Has to be done this way as TP does not patch quickly enough to prevent the initial entry point JMP, it will branch regardless (Thanks Pocky for workaround)
+
 			injector::WriteMemoryRaw(imageBase + 0xCBCB8, "\x8B\x84\x81\x94\x00\x00\x00\x8B\x40\x04", 10, true);	// Revert weird transmission patch?
 																													// Causes Seq/6MT to be disabled in pro mode
+			// End of dirty executable patches
 			
 			if (ToBool(config["General"]["IntroFix"]))
 			{


### PR DESCRIPTION
As title says. This PR adds some patches to fix-up a few different "dirty" executables that exist for battle gear 4 tuned. These include a patch which injects ttx_monitor.dll or JVSEmuBG.dll.

Both of these are likely interfere with teknoparrots hooks/patches and hence this patch will completely remove the ability for these altered executable files to inject said modules. These dlls both provide JVS hooks/patches that will conflict with ours.

One patch also fixes a (rather strange) patch in these tampered executables, which for some reason patches an offset lookup when deciding which transmission modes to make selectable on the transmission select. It patches the offset in the selected cars struct to 1 (I think) which causes it to grab a garbage value which causes MT/6MT to be disabled for every car in professional mode. This will also revert this patch to a clean state where this will not happen and game will behave as normal.

Please review and advise if any changes are required before merging. Have left some (maybe slightly _too_ detailed) code commends to hopefully help explain the reasoning behind these patches to other maintainers who may work on this game at a later date.