### PR TITLE
FNFSC Gear 2 fix

### DIFF
--- a/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
+++ b/OpenParrot/src/Functions/Games/Other/FNFSC.cpp
@@ -501,6 +501,13 @@ DWORD WINAPI InputRT2(LPVOID lpParam)
 				ChangeGear(2);
 			}
 		}
+		else
+		{
+			if (buttonGear2Pressed == true)
+			{
+				buttonGear2Pressed = false;
+			}
+		}
 
 		//GEAR 3
 		if (*ffbOffset5 & 0x4)


### PR DESCRIPTION
Once gear 2 was selected, it would never become unselected, causing big problems with gears.